### PR TITLE
nil return for getSmallestMap()

### DIFF
--- a/lib/init.lua
+++ b/lib/init.lua
@@ -358,7 +358,7 @@ local function getSmallestMap(componentIndex, components)
 		end
 	end
 	
-	return s.sparse
+	return s and s.sparse or nil
 end
 
 function World.query(world: World, ...: i53): any

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -192,7 +192,7 @@ local function onNotifyAdd(world, archetype, otherArchetype, row: number, added:
 end
 
 
-type World = typeof(World.new())
+export type World = typeof(World.new())
 
 local function ensureArchetype(world: World, types, prev)
 	if #types < 1 then


### PR DESCRIPTION
before, attempting to query over components that are not associated with any entities would cause the following error
![image](https://github.com/Ukendio/jecs/assets/58125798/323c672e-1a73-4888-9df2-fdf1b5919471)