### PR TITLE
World.component()

### DIFF
--- a/lib/init.lua
+++ b/lib/init.lua
@@ -525,7 +525,8 @@ function World.component(world: World)
 	if id > HI_COMPONENT_ID then 
 		error("Too many components")	
 	end
-	return id
+	world.nextId = id
+	return id + REST
 end
 
 function World.entity(world: World)


### PR DESCRIPTION
since `World.component(world)` was being unused, it is now treated the same exact way as `World.entity(world)`

```lua
local world = Jecs.World.new()

local Player = world:component()
local Health = world:component()

local someEntity = world:entity()

world:set(someEntity, Player, 0)
world:set(someEntity, Health, {
	current = 100,
	max = 100,
	regen = 0.01
})

for id, player, health in world:query(Player, Health) do
	print(id, player, health)
end

-- output: 263 0 { current = 100, max = 100, regen = 0.01 }
```