### PR TITLE
Rename Matter -> Jecs in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,9 +49,9 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          name: Matter ${{ github.ref_name }}
+          name: Jecs ${{ github.ref_name }}
           body: |
-            Matter ${{ github.ref_name }} is now available!
+            Jecs ${{ github.ref_name }} is now available!
           files: |
             jecs.rbxm
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,8 +50,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           name: Jecs ${{ github.ref_name }}
-          body: |
-            Jecs ${{ github.ref_name }} is now available!
           files: |
             jecs.rbxm
 


### PR DESCRIPTION
Seems like the script that built Matter was copy-pasted here. Just did some renaming in release.yaml so that someone doesn't have to manually rename all previous versions again.