### PR TITLE
Add null query unit tests

### DIFF
--- a/tests/world.luau
+++ b/tests/world.luau
@@ -497,7 +497,6 @@ TEST("world", function()
 		world:add(e1, A)
 
 		local query = world:query(B)
-		CHECK(query.__iter() == nil)
 		CHECK(query.next() == nil)
 		CHECK(query.replace() == nil)
 	end

--- a/tests/world.luau
+++ b/tests/world.luau
@@ -471,6 +471,22 @@ TEST("world", function()
 		CHECK(world:get(e, B) == false)
 		CHECK(world:get(e, C) == "hello world")
 	end
+
+	do CASE "should not iterate when nothing matches query"
+		local world = jecs.World.new()
+		local A = world:component()
+		local B = world:component()
+
+		local e1 = world:entity()
+		world:add(e1, A)
+
+		local count = 0
+		for id in world:query(B) do
+			count += 1
+		end
+
+		CHECK(count == 0)
+	end
 end)
 
 FINISH()

--- a/tests/world.luau
+++ b/tests/world.luau
@@ -488,7 +488,7 @@ TEST("world", function()
 		CHECK(count == 0)
 	end
 
-	do CASE "should use the same functions for empty iteration where applicable"
+	do CASE "should return nothing for empty iteration"
 		local world = jecs.World.new()
 		local A = world:component()
 		local B = world:component()
@@ -497,8 +497,9 @@ TEST("world", function()
 		world:add(e1, A)
 
 		local query = world:query(B)
-		CHECK(query.__iter == query.next)
-		CHECK(query.next == query.replace)
+		CHECK(query.__iter() == nil)
+		CHECK(query.next() == nil)
+		CHECK(query.replace() == nil)
 	end
 
 	do CASE "should properly handle query:without for empty iteration"

--- a/tests/world.luau
+++ b/tests/world.luau
@@ -487,6 +487,31 @@ TEST("world", function()
 
 		CHECK(count == 0)
 	end
+
+	do CASE "should use the same functions for empty iteration where applicable"
+		local world = jecs.World.new()
+		local A = world:component()
+		local B = world:component()
+
+		local e1 = world:entity()
+		world:add(e1, A)
+
+		local query = world:query(B)
+		CHECK(query.__iter == query.next)
+		CHECK(query.next == query.replace)
+	end
+
+	do CASE "should properly handle query:without for empty iteration"
+		local world = jecs.World.new()
+		local A = world:component()
+		local B = world:component()
+
+		local e1 = world:entity()
+		world:add(e1, A)
+
+		local query = world:query(B)
+		CHECK(query == query:without())
+	end
 end)
 
 FINISH()


### PR DESCRIPTION
Adds the following unit test in response to #67:

```lua
do CASE "should not iterate when nothing matches query"
	local world = jecs.World.new()
	local A = world:component()
	local B = world:component()

	local e1 = world:entity()
	world:add(e1, A)

	local count = 0
	for id in world:query(B) do
		count += 1
	end

	CHECK(count == 0)
end
```