### PR TITLE
Fix EmptyQuery to properly return an empty iterator

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -662,13 +662,15 @@ local function noop(_self: Query, ...): () -> ()
 end
 
 local EmptyQuery = {
-	__iter = iterNoop,
+	__iter = noop,
 	next = noop,
 	replace = noop,
 	without = function(self)
 		return self
 	end
 }
+
+setmetatable(EmptyQuery, EmptyQuery)
 
 export type Query = typeof(EmptyQuery)
 

--- a/src/init.luau
+++ b/src/init.luau
@@ -655,14 +655,14 @@ local function get(world: World, entityId: i53, a: i53, b: i53?, c: i53?, d: i53
 	end
 end
 
--- the less creation the better
-local function actualNoOperation() end
-local function noop(_self: Query, ...): () -> ()
-	return actualNoOperation :: any
+local function noop()
+	return nil
 end
 
 local EmptyQuery = {
-	__iter = noop,
+	__iter = function()
+		return noop
+	end,
 	next = noop,
 	replace = noop,
 	without = function(self)


### PR DESCRIPTION
Closes #67.

This PR fixes the empty query returning an unexpected iterator.