### PR TITLE
Add timeout to CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,7 @@ jobs:
   run:
     name: Run Luau Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 2
 
     steps:
       - name: Checkout Project


### PR DESCRIPTION
## Brief Description of your Changes.

Adds a timeout to the `ci.yaml` workflow to cap the total time allowed.

## Impact of your Changes

This will force the action to fail if a unit test hangs indefinitely.

## Tests Performed

Checked in fork and it seems to work in normal tests, but have not done any intensive tests yet.

## Additional Comments

Current timeout is 2 minutes since it takes less than a minute currently.