### PR TITLE
Improve workflows and use dedicated install luau script for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Run Unit Tests
         id: run_tests
         run: |
-          output=$(./luau test/tests.luau)
+          output=$(luau test/tests.luau)
           echo "$output"
           if [[ "$output" == *"0 fails"* ]]; then
             echo "Unit Tests Passed"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Luau
-        uses: encodedvenom/install-luau@v0.1.3
+        uses: encodedvenom/install-luau@v1
 
       - name: Run Unit Tests
         id: run_tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,14 +12,8 @@ jobs:
       - name: Checkout Project
         uses: actions/checkout@v4
 
-      - name: Fetch Luau Latest Release
-        run: curl -s https://api.github.com/repos/luau-lang/luau/releases/latest | grep /luau-ubuntu.zip | cut -d '"' -f 4 > luau-link.txt
-
-      - name: Download Luau Latest Release
-        run: wget -i luau-link.txt
-
-      - name: Unzip binary
-        run: unzip luau-ubuntu.zip
+      - name: Install Luau
+        uses: encodedvenom/install-luau@v0.1
 
       - name: Run Unit Tests
         id: run_tests
@@ -32,7 +26,3 @@ jobs:
             echo "Error: One or More Unit Tests Failed."
             exit 1
           fi
-
-      - name: Cleanup Luau Binaries
-        if: '!cancelled()'
-        run: rm luau && rm luau-analyze && rm luau-compile && rm luau-ubuntu.zip && rm luau-link.txt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Fetch Luau Latest Release
         run: curl -s https://api.github.com/repos/luau-lang/luau/releases/latest | grep /luau-ubuntu.zip | cut -d '"' -f 4 > luau-link.txt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Luau
-        uses: encodedvenom/install-luau@v0.1
+        uses: encodedvenom/install-luau@v0.1.1
 
       - name: Run Unit Tests
         id: run_tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Luau
-        uses: encodedvenom/install-luau@v0.1.2
+        uses: encodedvenom/install-luau@v0.1.3
 
       - name: Run Unit Tests
         id: run_tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Luau
-        uses: encodedvenom/install-luau@v0.1.1
+        uses: encodedvenom/install-luau@v0.1.2
 
       - name: Run Unit Tests
         id: run_tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Aftman
         uses: ok-nick/setup-aftman@v0.3.0
@@ -35,7 +35,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download Jecs Build
         uses: actions/download-artifact@v3
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Aftman
         uses: ok-nick/setup-aftman@v0.3.0


### PR DESCRIPTION
## Brief Description of your Changes.

Increments the actions/checkout version to a non-deprecated version and uses a dedicated action for fetching luau.

## Impact of your Changes

This makes it easier for others to understand what's going on inside of the CI file and the other files will be using a non-deprecated version for checkout.

## Tests Performed

[It runs on my local fork](https://github.com/EncodedVenom/jecs/actions/runs/9931622092/job/27431729311)

## Additional Comments

This adds a [new dependency](https://github.com/EncodedVenom/install-luau), which is maintained by myself. But given how it's as minimal as possible, it should be relatively fine for this goals of this project.