### PR TITLE
Fix types of `OnAdd`, `OnRemove` and `OnSet`

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -1549,9 +1549,9 @@ export type World = {
 return {
 	World = World :: { new: () -> World },
 
-	OnAdd = EcsOnAdd :: Entity,
-	OnRemove = EcsOnRemove :: Entity,
-	OnSet = EcsOnSet :: Entity,
+	OnAdd = EcsOnAdd :: Entity<(entity: Entity) -> ()>,
+	OnRemove = EcsOnRemove :: Entity<(entity: Entity) -> ()>,
+	OnSet = EcsOnSet :: Entity<(entity: Entity, data: any) -> ()>,
 	ChildOf = EcsChildOf :: Entity,
 	Component = EcsComponent :: Entity,
 	Wildcard = EcsWildcard :: Entity,


### PR DESCRIPTION
## Brief Description of your Changes.

The `OnAdd`, `OnRemove` and `OnSet` traits were typed as `Entity<nil>` leading to the type checker freaking out
![image](https://github.com/user-attachments/assets/e1d4db62-0fec-43c6-96a0-b26dc1868371)

## Impact of your Changes

Improved type checking

## Tests Performed

Implemented exactly what was told to be implemented and how

## Additional Comments

Said `Entity<any>` instead of `Entity<nil>` in commit :(