### PR TITLE
Expose `world:contains()` and `query:drain()` in types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog][kac], and this project adheres to
       - Applies to `world:add()`, `world:set()`, `world:remove()`, `world:get()`, `world:has()` and `world:query()`
       - New exported type `Id<T = nil> = Entity<T> | Pair`
     - Make `world:contains()` return a `boolean` instead of an entity which may or may not exist
+    - Fix `world:has()` to explicitly take in an entity (new: `(self: World, entity: Entity, ...id) -> boolean`, old: `(self: World, ...Id) -> boolean`)
 
 ## [0.2.2] - 2024-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog][kac], and this project adheres to
 - `[luau]`:
     - Exported Query
     - Improved types for the hooks `OnAdd`, `OnSet`, `OnRemove`
+    - Expose `world:contains()` in `World` type and expose `query:drain()` in `Query` type
+    - Allow functions to accept any ID including pairs in type parameters
+      - Applies to `world:add()`, `world:set()`, `world:remove()`, `world:get()`, `world:has()` and `world:query()`
+      - New exported type `Id<T = nil> = Entity<T> | Pair`
+    - Make `world:contains()` return a `boolean` instead of an entity which may or may not exist
 
 ## [0.2.2] - 2024-07-07
 

--- a/src/init.luau
+++ b/src/init.luau
@@ -1493,6 +1493,7 @@ type Query<T...> = typeof(setmetatable({}, {
 })) & {
     iter: Iter<T...>,
     next: Item<T...>,
+    drain: (self: Query<T...>) -> Query<T...>,
     with: (self: Query<T...>, ...i53) -> Query<T...>,
     without: (self: Query<T...>, ...i53) -> Query<T...>,
     replace: (self: Query<T...>, <U...>(T...) -> (U...)) -> (),

--- a/src/init.luau
+++ b/src/init.luau
@@ -1537,7 +1537,7 @@ export type World = {
 			& (<A, B, C>(self: World, id: Entity, Id<A>, Id<B>, Id<C>) -> (A?, B?, C?))
 			& <A, B, C, D>(self: World, id: Entity, Id<A>, Id<B>, Id<C>, Id<D>) -> (A?, B?, C?, D?),
 
-		has: (self: World, ...Id) -> boolean,
+		has: (self: World, entity: Entity, ...Id) -> boolean,
 
 		parent: (self: World, entity: Entity) -> Entity,
 

--- a/src/init.luau
+++ b/src/init.luau
@@ -921,9 +921,8 @@ function world_delete(world: World, entity: i53)
 	entityIndex.sparse[entity] = nil
 end
 
-local function world_contains(world: World, entity)
-
-    return world.entityIndex.sparse[entity]
+local function world_contains(world: World, entity): boolean
+    return world.entityIndex.sparse[entity] ~= nil
 end
 
 type CompatibleArchetype = { archetype: Archetype, indices: { number } }
@@ -1540,6 +1539,9 @@ export type World = {
 		has: (self: World, ...Id) -> boolean,
 
 		parent: (self: World, entity: Entity) -> Entity,
+
+		--- Checks if the world contains the given entity
+		contains: (self: World, entity: Entity) -> boolean,
 
 		--- Searches the world for entities that match a given query
 		query: (<A>(self: World, Id<A>) -> Query<A>)


### PR DESCRIPTION
## Brief Description of your Changes.

+ Expose `world:contains()` in `World` type
+ Expose `query:drain()` in `Query` type
+ Make `world:contains()` return a `boolean` instead of an entity which may or may not exist

## Impact of your Changes

Developers can now use another two methods without casting the objects to have them
Doesn't alter performance, although alters behavior if someone expects `world:contains()` to return an entity (impossibly unlikely, especially since the method itself was never exposed in types)

## Tests Performed

Run tests and implement as directed

## Additional Comments

N/A