### PR TITLE
Allow nil indexing in world:target

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -95,10 +95,20 @@ export class World {
      * Gets the target of a relationship. For example, when a user calls
      * `world.target(entity, ChildOf(parent))`, you will obtain the parent entity.
      * @param entity Entity
+     * @param index Target index
      * @param relation The Relationship
      * @returns The Parent Entity if it exists
      */
     target(entity: Entity, relation: Entity, index: number): Entity | undefined;
+
+    /**
+     * Gets the target of a relationship. For example, when a user calls
+     * `world.target(entity, ChildOf(parent))`, you will obtain the parent entity.
+     * @param entity Entity
+     * @param relation The Relationship
+     * @returns The Parent Entity if it exists
+     */
+    target(entity: Entity, relation: Entity): Entity | undefined;
 
     /**
      * Clears an entity from the world.

--- a/src/init.luau
+++ b/src/init.luau
@@ -389,7 +389,8 @@ local function world_has(world: World, entity: number, ...: i53): boolean
 	return true
 end
 
-local function world_target(world: World, entity: i53, relation: i24, index: number): i24?
+local function world_target(world: World, entity: i53, relation: i24, index_opt: number?): i24?
+	local index = if index_opt then index_opt else 0
 	local record = world.entityIndex.sparse[entity]
 	local archetype = record.archetype
 	if not archetype then

--- a/src/init.luau
+++ b/src/init.luau
@@ -1813,7 +1813,7 @@ export type World = {
 	component: <T>(self: World) -> Entity<T>,
 	--- Gets the target of an relationship. For example, when a user calls
 	--- `world:target(id, ChildOf(parent), 0)`, you will obtain the parent entity.
-	target: (self: World, id: Entity, relation: Entity, nth: number) -> Entity?,
+	target: (self: World, id: Entity, relation: Entity, nth: number?) -> Entity?,
 	--- Deletes an entity and all it's related components and relationships.
 	delete: (self: World, id: Entity) -> (),
 

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -1026,12 +1026,9 @@ TEST("world:target", function()
         world:add(e, pair(B, D))
         world:add(e, pair(C, D))
 
-        CHECK(world:target(e, A) == B)
-        CHECK(world:target(e, A, 1) == C)
-        CHECK(world:target(e, B) == C)
-        CHECK(world:target(e, B, 1) == D)
-        CHECK(world:target(e, C) == D)
-        CHECK(world:target(e, C, 1) == nil)
+        CHECK(world:target(e, A) == world:target(e, A, 0))
+        CHECK(world:target(e, B) == world:target(e, B, 0))
+        CHECK(world:target(e, C) == world:target(e, C, 0))
     end
 
     do CASE "loop until no target"

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -1012,6 +1012,28 @@ TEST("world:target", function()
         CHECK(world:target(e, C, 1) == nil)
     end
 
+    do CASE "infer index when unspecified"
+        local world = world_new()
+        local A = world:component()
+        local B = world:component()
+        local C = world:component()
+        local D = world:component()
+        local e = world:entity()
+
+        world:add(e, pair(A, B))
+        world:add(e, pair(A, C))
+        world:add(e, pair(B, C))
+        world:add(e, pair(B, D))
+        world:add(e, pair(C, D))
+
+        CHECK(world:target(e, A) == B)
+        CHECK(world:target(e, A, 1) == C)
+        CHECK(world:target(e, B) == C)
+        CHECK(world:target(e, B, 1) == D)
+        CHECK(world:target(e, C) == D)
+        CHECK(world:target(e, C, 1) == nil)
+    end
+
     do CASE "loop until no target"
         local world = world_new()
 


### PR DESCRIPTION
## Brief Description of your Changes.

This PR allows for users to use `world:target(entity, relationship, index)` without specifying an index. If none is specified, this will default to `0` internally.

For example,

```luau
world:target(entity, ChildOf(parent), 0)
```

Can now be written like:

```luau
world:target(entity, ChildOf(parent))
```

## Impact of your Changes

This will allow backwards compatibility with previous versions of jecs which did not have the index in `world:target`

## Tests Performed

Added a test in the testing suite to track this change. [This test passes CI.](https://github.com/Ukendio/jecs/actions/runs/10994038793/job/30521801373)