### PR TITLE
Fix typo with `archetype_traverse_remove`

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -687,7 +687,7 @@ end
 local function archetype_traverse_remove(world: World, id: i53, from: Archetype): Archetype
 	from = from or world.ROOT_ARCHETYPE
 
-	local edge = archetype_ensure_edge(world, from.node.add, id)
+	local edge = archetype_ensure_edge(world, from.node.remove, id)
 
 	local to = edge.to
 	if not to then


### PR DESCRIPTION
Fixes typo that passed in `from.node.add` instead of `from.node.remove` to `archetype_ensure_edge`, which led to `world:remove` not working after a `world:set`.

Reproduction of issue:
```lua
local jecs = require(game.ReplicatedStorage.jecs)
local world = jecs.World.new()

local Cooldown = world:component()

local ent = world:entity()
world:set(ent, Cooldown, 2)

local function updateCooldowns(dt: number)
	local toRemove = {}

	for id, cooldown in world:query(Cooldown) do
		cooldown -= dt

		if cooldown <= 0 then
			table.insert(toRemove, id)
		else
			world:set(id, Cooldown, cooldown)
		end
	end

	for _, id in pairs(toRemove) do
		world:remove(id, Cooldown)
	end
end

updateCooldowns(1)
updateCooldowns(1)
assert(not world:has(ent, Cooldown))
```