### PR TITLE
Remove `world:target` debug error

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -1709,12 +1709,6 @@ if _G.__JECS_DEBUG then
 
 		return world_get(world, entity, ...)
 	end
-
-	World.target = function(world, entity, relation, index)
-		return world_target(world, entity, relation, index)
-	end
-
-	World.remove = function() end
 end
 
 function World.new()

--- a/src/init.luau
+++ b/src/init.luau
@@ -1710,19 +1710,6 @@ if _G.__JECS_DEBUG then
 		return world_get(world, entity, ...)
 	end
 
-	World.target = function(world, entity, relation, index)
-		if index == nil then
-			local _1 = get_name(world, entity)
-			local _2 = get_name(world, relation)
-
-			throw(
-				"We have changed the function call to require an index parameter,"
-					.. ` please use world:target({_1}, {_2}, 0)`
-			)
-		end
-		return world_target(world, entity, relation, index)
-	end
-
 	World.remove = function() end
 end
 

--- a/src/init.luau
+++ b/src/init.luau
@@ -1710,6 +1710,10 @@ if _G.__JECS_DEBUG then
 		return world_get(world, entity, ...)
 	end
 
+	World.target = function(world, entity, relation, index)
+		return world_target(world, entity, relation, index)
+	end
+
 	World.remove = function() end
 end
 


### PR DESCRIPTION
## Brief Description
This PR removes the debug error about `world:target` needing an `index` parameter. 
The parameter was made optional in #131.

## Impact
This will fix compatibility with working code in non debug mode.