### PR TITLE
Update ts type definitions

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+	"printWidth": 120,
+	"tabWidth": 4,
+	"trailingComma": "all",
+	"useTabs": true
+}


### PR DESCRIPTION
## Brief Description of Your Changes

This pull request introduces generic TS type definitions for pairs `Pair<P, O, V = P`, as well as proper handling of tags `Entity<undefined>` when used in the set function. Additionally, it updates the types for queries to align with the latest changes seen in jecs, where the `drain` and `next` methods have been consolidated into a single `iter()` function.

Also, adds a .prettierrc file to ensure the styling of .d.ts remains consistent.