### PR TITLE
fix: `query:archetypes()` didnt take self in type

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -1681,7 +1681,7 @@ type Query<T...> = typeof(setmetatable({}, {
 	with: (self: Query<T...>, ...i53) -> Query<T...>,
 	without: (self: Query<T...>, ...i53) -> Query<T...>,
 	replace: (self: Query<T...>, <U...>(T...) -> U...) -> (),
-	archetypes: () -> { Archetype },
+	archetypes: (self: Query<T...>) -> { Archetype },
 }
 
 export type World = {


### PR DESCRIPTION
## Brief Description of your Changes.

Fix the public facing type of `query:archetypes()` not taking in self, resulting in the type checker erroring when calling it.

## Impact of your Changes

Better type checking, no performance changes.

## Tests Performed

Edit purely types.

## Additional Comments

N/A