### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/api/jecs.md
+++ b/docs/api/jecs.md
@@ -40,7 +40,7 @@ jecs.Rest: Entity
 function jecs.pair(
     first: Entity, -- The first element of the pair, referred to as the relationship of the relationship pair.
     object: Entity, -- The second element of the pair, referred to as the target of the relationship pair.
-): number -- Returns the Id with those two elements
+): number -- Returns the ID with those two elements
 
 ```
 ::: info

--- a/docs/api/query.md
+++ b/docs/api/query.md
@@ -84,5 +84,5 @@ end
 ```
 
 :::info
-This function is meant for people who wants to really customize their query behaviour at the archetype-level
+This function is meant for people who want to really customize their query behaviour at the archetype-level
 :::

--- a/docs/learn/concepts/component-traits.md
+++ b/docs/learn/concepts/component-traits.md
@@ -102,7 +102,7 @@ world:add(Archer, pair(jecs.OnDelete, jecs.Delete))
 local e = world:entity()
 world:add(e, Archer)
 
--- This will delete entity e
+-- This will delete entity e because the Archer component has a (OnDelete, Delete) cleanup trait
 world:delete(Archer)
 ```
 
@@ -113,7 +113,7 @@ world.add(Archer, pair(jecs.OnDelete, jecs.Delete))
 const e = world:entity()
 world.add(e, Archer)
 
-// This will delete entity e
+// This will delete entity e because the Archer component has a (OnDelete, Delete) cleanup trait
 world.delete(Archer)
 ```
 

--- a/docs/learn/concepts/component-traits.md
+++ b/docs/learn/concepts/component-traits.md
@@ -97,23 +97,23 @@ world.delete(Archer)
 
 ```luau [luau]
 local Archer = world:component()
-world:add(Archer, pair(jecs.OnDelete, jecs.Remove))
+world:add(Archer, pair(jecs.OnDelete, jecs.Delete))
 
 local e = world:entity()
 world:add(e, Archer)
 
--- This will remove Archer from e
+-- This will delete entity e
 world:delete(Archer)
 ```
 
 ```typescript [typescript]
 const Archer = world.component()
-world.add(Archer, pair(jecs.OnDelete, jecs.Remove))
+world.add(Archer, pair(jecs.OnDelete, jecs.Delete))
 
 const e = world:entity()
 world.add(e, Archer)
 
-// This will remove Archer from e
+// This will delete entity e
 world.delete(Archer)
 ```
 

--- a/docs/learn/concepts/relationships.md
+++ b/docs/learn/concepts/relationships.md
@@ -22,10 +22,10 @@ Test if entity has a relationship pair
 
 :::code-group
 ```luau [luau]
-world:has(bob, pair(Eats, Apples)
+world:has(bob, pair(Eats, Apples))
 ```
 ```typescript [typescript]
-world.has(bob, pair(Eats, Apples)
+world.has(bob, pair(Eats, Apples))
 ```
 :::
 
@@ -190,7 +190,7 @@ Because of the way pair IDs are encoded, a pair will never be in the low id rang
 ### Fragmentation
 Fragmentation is a property of archetype-based ECS implementations where entities are spread out over more archetypes as the number of different component combinations increases. The overhead of fragmentation is visible in two areas:
 - Archetype creation
-- ueries (queries have to match & iterate more archetypes)
+- Queries (queries have to match & iterate more archetypes)
 Games that make extensive use of relationships might observe high levels of fragmentation, as relationships can introduce many different combinations of components. While the Jecs storage is optimized for supporting large amounts (hundreds of thousands) of archetypes, fragmentation is a factor to consider when using relationships.
 
 Union relationships are planned along with other improvements to decrease the overhead of fragmentation introduced by relationships.
@@ -205,6 +205,6 @@ The opposite is also true. Because relationship pairs can contain regular entiti
 
 To improve the speed of evaluating queries, Jecs has indices that store all archetypes for a given component ID. Whenever a new archetype is created, it is registered with the indices for the IDs the archetype has, including IDs for relationship pairs.
 
-While registering a archetype for a relationship index is not more expensive than registering a archetype for a regular index, a archetype with relationships has to also register itself with the appropriate wildcard indices for its relationships. For example, an archetype with relationship `pair(Likes, Apples)` registers itself with the `pair(Likes, Apples)`, `pair(Likes, jecs.Wildcard)` and `pair(jecs.Wildcard, Apples)` indices. For this reason, creating new archetypes with relationships has a higher overhead than a archetype without relationships.
+While registering an archetype for a relationship index is not more expensive than registering an archetype for a regular index, an archetype with relationships has to also register itself with the appropriate wildcard indices for its relationships. For example, an archetype with relationship `pair(Likes, Apples)` registers itself with the `pair(Likes, Apples)`, `pair(Likes, jecs.Wildcard)` and `pair(jecs.Wildcard, Apples)` indices. For this reason, creating new archetypes with relationships has a higher overhead than an archetype without relationships.
 
 This page takes wording and terminology directly from Flecs, the first ECS with full support for [Entity Relationships](https://www.flecs.dev/flecs/md_docs_2Relationships.html).

--- a/docs/learn/overview/first-jecs-project.md
+++ b/docs/learn/overview/first-jecs-project.md
@@ -65,7 +65,7 @@ for (const [id, position, velocity] of world.query(Position, Velocity)) {
 
 ## Where To Get Help
 
-If you are encounting problems, there are resources for you to get help:
+If you are encountering problems, there are resources for you to get help:
 - [Roblox OSS Discord server](https://discord.gg/h2NV8PqhAD) has a [#jecs](https://discord.com/channels/385151591524597761/1248734074940559511) thread under the [#projects](https://discord.com/channels/385151591524597761/1019724676265676930) channel
 - [Open an issue](https://github.com/ukendio/jecs/issues) if you run into bugs or have feature requests
 - Dive into the nitty gritty in the [thesis paper](https://raw.githubusercontent.com/Ukendio/jecs/main/thesis/drafts/1/paper.pdf)


### PR DESCRIPTION
## Brief Description of your Changes.

Fixes the typos in various parts of the docs. Fixes #149 

## Impact of your Changes

Clarity of docs.

## Tests Performed

What have you done to ensure this change has the least possible impact on the project?

## Additional Comments

The [query](https://ukendio.github.io/jecs/api/query.html#query) intro still contains the same definition as the [World](https://ukendio.github.io/jecs/api/query.html#query) intro. Not quite sure what to change it to