### PR TITLE
packaging(wally): Add license to package and manifest

### DIFF
--- a/wally.toml
+++ b/wally.toml
@@ -3,6 +3,7 @@ name = "ukendio/jecs"
 version = "0.3.2"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
+license = "MIT"
 include = [
     "default.project.json",
     "src/**",
@@ -10,5 +11,6 @@ include = [
     "wally.toml",
     "README.md",
     "CHANGELOG.md",
+    "LICENSE",
 ]
 exclude = ["**"]


### PR DESCRIPTION
## Brief Description of your Changes.

Add the MIT license to the wally manifest and include it in the package.

## Impact of your Changes

Clearer licensing.

## Tests Performed

N/A

## Additional Comments

A link to the license is included in the README, although it's clearer to have a dedicated `LICENSE` file included in the package.