### PR TITLE
Add pesde support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,5 +67,11 @@ jobs:
       - name: Wally Login
         run: wally login --token ${{ secrets.WALLY_AUTH_TOKEN }}
 
-      - name: Publish
+      - name: Wally Publish
         run: wally publish
+        
+      - name: Pesde Login
+        run: pesde auth login --token "${{ secrets.PESDE_AUTH_TOKEN }}"
+        
+      - name: Pesde Publish
+        run: pesde publish -y

--- a/pesde.toml
+++ b/pesde.toml
@@ -1,0 +1,21 @@
+name = "ukendio/jecs"
+authors = ["jecs authors"]
+description = "A fast, portable Entity Component System for Luau"
+includes = [
+    "src",
+    "pesde.toml",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE",
+    ".luaurc",
+]
+license = "MIT"
+repository = "https://github.com/Ukendio/jecs"
+version = "0.3.2"
+
+[indices]
+default = "https://github.com/daimond113/pesde-index"
+
+[target]
+environment = "luau"
+lib = "init.luau"


### PR DESCRIPTION
## Brief Description of your Changes.

+ Create a pesde manifest
+ Add pesde publishing to the release action

## Impact of your Changes

Greater support for using jecs in pure luau or with a runtime with a package manager.

## Tests Performed

N/A

## Additional Comments

Ticks all pesde related tasks @ #153 
A pesde authorization token needs to be added as a secret under the name of `PESDE_AUTH_TOKEN`.