### PR TITLE
resolves requiring ecs path issue for demo

### DIFF
--- a/demo/default.project.json
+++ b/demo/default.project.json
@@ -6,7 +6,7 @@
             "$className": "ReplicatedStorage",
             "$path": "src/ReplicatedStorage",
             "ecs": {
-                "$path": "../src"
+                "$path": "../jecs.luau"
             },
             "net": {
                 "$path": "net/client.luau"


### PR DESCRIPTION
## Brief Description of your Changes.

Resolves the jecs require in the `default.project.json` file in the jecs demo folder. The path to jecs was changed previously and the `src` folder was deleted. This PR just updates the project json file so it reads the new jecs path.

## Impact of your Changes

No implications as this is just a small bug fix

## Tests Performed

Tested it in a clean Workspace by syncing the project via rojo. 
Confirmed that the ecs file was synced properly. 
Confirmed that the changes are working by running the test game

## Additional Comments
First PR lets goo