### PR TITLE
Fix table.move usage in query_cached

### DIFF
--- a/jecs.luau
+++ b/jecs.luau
@@ -1589,7 +1589,7 @@ local function query_cached(query: QueryInner)
 	local with = query.filter_with
 	local ids = query.ids
 	if with then
-		table.move(ids, 1, #ids, #with, with)
+		table.move(ids, 1, #ids, #with + 1, with)
 	else
 		query.filter_with = ids
 	end

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -1495,5 +1495,22 @@ TEST("repro", function()
 		end
 		CHECK(counter == 1)
 	end
+
+	do CASE "#3" -- ISSUE #171
+		local world = world_new()
+		local component1 = world:component()
+		local tag1 = world:entity()
+		
+		local query = world:query(component1):with(tag1):cached()
+		
+		local entity = world:entity()
+		world:set(entity, component1, "some data")
+
+		local counter = 0
+		for x in query:iter() do
+			counter += 1
+		end
+		CHECK(counter == 0)
+	end
 end)
 FINISH()


### PR DESCRIPTION
Move components from `query.ids` to `#with + 1` instead of directly at `#with`.

Related to #171.