### PR TITLE
fix 'jecs.World.new()' being inferred to return 'any'

### DIFF
--- a/jecs.luau
+++ b/jecs.luau
@@ -2311,7 +2311,7 @@ export type World = {
 }
 
 return {
-	World = World,
+	World = World :: { new: () -> World },
 
 	OnAdd = EcsOnAdd :: Entity<(entity: Entity) -> ()>,
 	OnRemove = EcsOnRemove :: Entity<(entity: Entity) -> ()>,


### PR DESCRIPTION
## Brief Description of your Changes.

Fix `jecs.World.new()` to be typed as returning a `World` instead of `any`, via type casting the `World` class returned by jecs.

## Impact of your Changes

Better typechecking.

## Tests Performed

-

## Additional Comments

-