### PR TITLE
Fixed world:delete() not invoking OnRemove hooks.

### DIFF
--- a/jecs.luau
+++ b/jecs.luau
@@ -960,7 +960,7 @@ local function archetype_delete(world: World, archetype: Archetype, row: number,
 	local component_index = world.componentIndex
 	for _, id in id_types do
 		local idr = component_index[id]
-		local on_remove: idr.hooks.on_remove
+		local on_remove = idr.hooks.on_remove
 		if on_remove then
 			on_remove(delete)
 		end

--- a/jecs.luau
+++ b/jecs.luau
@@ -619,7 +619,7 @@ local function archetype_create(world: World, id_types: { i24 }, ty, prev: i53?)
 		end
 	end
 
-	for _, id in id_types do
+	for id in records do
 		local observer_list = find_observers(world, EcsOnArchetypeCreate, id)
 		if not observer_list then
 			continue

--- a/jecs.luau
+++ b/jecs.luau
@@ -957,8 +957,10 @@ local function archetype_delete(world: World, archetype: Archetype, row: number,
 
 	-- TODO: if last == 0 then deactivate table
 
+	local component_index = world.componentIndex
 	for _, id in id_types do
-		local on_remove: (entity: i53) -> () = world_get_one_inline(world, id, EcsOnRemove)
+		local idr = component_index[id]
+		local on_remove: idr.hooks.on_remove
 		if on_remove then
 			on_remove(delete)
 		end

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -1673,7 +1673,7 @@ TEST("world:delete() invokes OnRemove hook", function()
 		end)
 
 		world:add(entity, A)
-		world:delete()
+		world:delete(entity)
 
 		CHECK(called)
 	end

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -1433,13 +1433,13 @@ TEST("change tracking", function()
 		local i = 0
 		for entity, number in q1 do
 			i += 1
-		    world:add(testEntity, tag)
+			world:add(testEntity, tag)
 		end
 
 		CHECK(i == 1)
 
 		for e, n in q1 do
-		    world:set(e, pair(previous, component), n)
+			world:set(e, pair(previous, component), n)
 		end
 	end
 
@@ -1592,6 +1592,71 @@ TEST("repro", function()
 			counter += 1
 		end
 		CHECK(counter == 0)
+	end
+end)
+
+TEST("wildcard query", function()
+	do CASE "#1"
+		local world = world_new()
+		local pair = jecs.pair
+
+		local Relation = world:entity()
+		local Wildcard = jecs.Wildcard
+		local A = world:entity()
+
+		local relationship = pair(Relation, Wildcard)
+		local query = world:query(relationship):cached()
+
+		local entity = world:entity()
+
+		world:add(entity, pair(Relation, A))
+
+		local counter = 0
+		for e in query:iter() do
+			counter += 1
+		end
+		CHECK(counter == 1)
+	end
+	do CASE "#2"
+		local world = world_new()
+		local pair = jecs.pair
+
+		local Relation = world:entity()
+		local Wildcard = jecs.Wildcard
+		local A = world:entity()
+
+		local relationship = pair(Relation, Wildcard)
+
+		local entity = world:entity()
+
+		world:add(entity, pair(Relation, A))
+
+		local counter = 0
+		for e in world:query(relationship):iter() do
+			counter += 1
+		end
+		CHECK(counter == 1)
+	end
+	do CASE "#3"
+		local world = world_new()
+		local pair = jecs.pair
+
+		local Relation = world:entity()
+		local Wildcard = jecs.Wildcard
+		local A = world:entity()
+
+		local entity = world:entity()
+
+		world:add(entity, pair(Relation, A))
+
+		local relationship = pair(Relation, Wildcard)
+		local query = world:query(relationship):cached()
+
+		local counter = 0
+		for e in query:iter() do
+			counter += 1
+		end
+		CHECK(counter == 1)
 	end
 end)
 FINISH()

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -1694,8 +1694,8 @@ TEST("world:delete() invokes OnRemove hook", function()
 			called = true
 		end)
 
-		world:add(entity, A)
-		world:add(entity, pair(Relation, B))
+		world:add(entity, B)
+		world:add(entity, pair(Relation, A))
 		
 		world:remove(entity, B)
 

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -1659,4 +1659,47 @@ TEST("wildcard query", function()
 		CHECK(counter == 1)
 	end
 end)
+
+TEST("world:delete() invokes OnRemove hook", function()
+	do CASE "#1"
+		local world = world_new()
+		
+		local A = world:entity()
+		local entity = world:entity()
+
+		local called = false
+		world:set(A, jecs.OnRemove, function(e)
+			called = true
+		end)
+
+		world:add(entity, A)
+		world:delete()
+
+		CHECK(called)
+	end
+	do CASE "#2"
+		local world = world_new()
+		local pair = jecs.pair
+
+		local Relation = world:entity()
+		local A = world:entity()
+		local B = world:entity()
+
+		world:add(B, pair(jecs.OnDelete, jecs.Delete))
+
+		local entity = world:entity()
+
+		local called = false
+		world:set(A, jecs.OnRemove, function(e)
+			called = true
+		end)
+
+		world:add(entity, A)
+		world:add(entity, pair(Relation, B))
+		
+		world:remove(entity, B)
+
+		CHECK(called)
+	end
+end)
 FINISH()

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -1685,7 +1685,7 @@ TEST("world:delete() invokes OnRemove hook", function()
 		local A = world:entity()
 		local B = world:entity()
 
-		world:add(B, pair(jecs.OnDelete, jecs.Delete))
+		world:add(Relation, pair(jecs.OnDelete, jecs.Delete))
 
 		local entity = world:entity()
 
@@ -1694,8 +1694,8 @@ TEST("world:delete() invokes OnRemove hook", function()
 			called = true
 		end)
 
-		world:add(entity, B)
-		world:add(entity, pair(Relation, A))
+		world:add(entity, A)
+		world:add(entity, pair(Relation, B))
 		
 		world:delete(B)
 

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -1697,7 +1697,7 @@ TEST("world:delete() invokes OnRemove hook", function()
 		world:add(entity, B)
 		world:add(entity, pair(Relation, A))
 		
-		world:remove(entity, B)
+		world:delete(B)
 
 		CHECK(called)
 	end


### PR DESCRIPTION
## Brief Description of your Changes.

Fixed world:delete() not invoking OnRemove component hooks.

## Impact of your Changes

world:delete() will now invoke OnRemove hooks.

## Tests Performed

See: https://github.com/Intrinsic-zyx/jecs/blob/a0c6e7bd87bb0fd5a7f4c6e6028d98a5f05a57e2/test/tests.luau#L1663

Case #1 simply ensure the invocation of the OnRemove hook after world:delete is called upon an entity containing the hooked component.

Case #2 ensures that cleanup traits properly invoke the OnRemove hook as well.