### PR TITLE
Fixed hooks invocation in the event of relationship target deletion.

### DIFF
--- a/jecs.luau
+++ b/jecs.luau
@@ -1158,7 +1158,7 @@ do
 				local idr_t_archetype = archetypes[archetype_id]
 
 				local idr_t_types = idr_t_archetype.types
-				local on_remove = idr_t.hooks.on_remove
+				
 
 				for _, child in idr_t_archetype.entities do
 					table.insert(children, child)
@@ -1180,6 +1180,7 @@ do
 							end
 							break
 						else
+							local on_remove = id_record.hooks.on_remove
 							local to = archetype_traverse_remove(world, id, idr_t_archetype)
 							if on_remove then
 								for _, child in children do

--- a/jecs.luau
+++ b/jecs.luau
@@ -1158,7 +1158,6 @@ do
 				local idr_t_archetype = archetypes[archetype_id]
 
 				local idr_t_types = idr_t_archetype.types
-				
 
 				for _, child in idr_t_archetype.entities do
 					table.insert(children, child)

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -1705,7 +1705,7 @@ TEST("world:delete() invokes OnRemove hook", function()
 		local world = world_new()
 		local pair = jecs.pair
 
-		local viewingContainer = world:component()
+		local viewingContainer = world:entity()
 		local character = world:entity()
 		local container = world:entity()
 

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -1701,5 +1701,24 @@ TEST("world:delete() invokes OnRemove hook", function()
 
 		CHECK(called)
 	end
+	do CASE "#3"
+		local world = world_new()
+		local pair = jecs.pair
+
+		local viewingContainer = world:component()
+		local character = world:entity()
+		local container = world:entity()
+
+		local called = false
+		world:set(viewingContainer, jecs.OnRemove, function(e)
+			called = true
+		end)
+
+		world:add(character, pair(viewingContainer, container))
+
+		world:delete(container)
+
+		CHECK(called)
+	end
 end)
 FINISH()


### PR DESCRIPTION
Followup to: #178, fixes [OnRemove hook not being invoked upon the deletion of a relationship target](https://discord.com/channels/385151591524597761/1248734074940559511/1329602727470305332)

Co-authored-by: @lolmanurfunny