### PR TITLE
Remove sapphire-jecs, add rubine

### DIFF
--- a/docs/learn/concepts/addons.md
+++ b/docs/learn/concepts/addons.md
@@ -9,8 +9,8 @@ A jecs debugger with a string-based query language and entity editing capabiliti
 ## [lockstep scheduler](https://gist.github.com/1Axen/6d4f78b3454cf455e93794505588354b)
 A simple fixed step system scheduler.
 
-## [sapphire-jecs](https://github.com/Mark-Marks/sapphire/tree/main/crates/sapphire-jecs)
-A batteries-included [sapphire](https://github.com/mark-marks/sapphire) scheduler for jecs
+## [rubine](https://github.com/Mark-Marks/rubine)
+An ergonomic, runtime agnostic scheduler for Jecs
 
 ## [jam](https://github.com/revvy02/Jam)
 Provides hooks and a scheduler that implements jabby and a topographical runtime


### PR DESCRIPTION
## Brief Description of your Changes.

Replaces [sapphire-jecs](https://github.com/Mark-Marks/sapphire) with [rubine](https://github.com/Mark-Marks/rubine) in the addons page.

## Impact of your Changes

-

## Tests Performed

-

## Additional Comments

-