### PR TITLE
Typescript: Types for Archetype in Query and CachedQuery

### DIFF
--- a/jecs.d.ts
+++ b/jecs.d.ts
@@ -40,9 +40,6 @@ type FlattenTuple<T extends unknown[]> = T extends [infer U] ? U : LuaTuple<T>;
 type Nullable<T extends unknown[]> = { [K in keyof T]: T[K] | undefined };
 type InferComponents<A extends Id[]> = { [K in keyof A]: InferComponent<A[K]> };
 
-type i53 = number
-type i24 = number
-type Ty =  i53[];
 type ArchetypeId = number
 type Column = unknown[];
 
@@ -53,7 +50,7 @@ type ArchetypeRecord = {
 
 export type Archetype = {
     id: number;
-    types: Ty;
+    types: number[];
     type: string;
     entities: number[];
     columns: Column[];

--- a/jecs.d.ts
+++ b/jecs.d.ts
@@ -69,8 +69,8 @@ export type CachedQuery<T extends unknown[]> = {
 	iter(): Iter<T>;
 
 	/**
-	 * Returns the archetype of the query
-	 * @returns An array of archetype of the query
+	 * Returns the matched archetypes of the query
+	 * @returns An array of archetypes of the query
 	 */
 	archetypes(): Archetype[];
 } & Iter<T>;
@@ -103,8 +103,8 @@ export type Query<T extends unknown[]> = {
 	without(...components: Id[]): Query<T>;
 
 	/**
-	 * Returns the archetype of the query
-	 * @returns An array of archetype of the query
+	 * Returns the matched archetypes of the query
+	 * @returns An array of archetypes of the query
 	 */
 	archetypes(): Archetype[];
 } & Iter<T>;

--- a/jecs.d.ts
+++ b/jecs.d.ts
@@ -40,6 +40,26 @@ type FlattenTuple<T extends unknown[]> = T extends [infer U] ? U : LuaTuple<T>;
 type Nullable<T extends unknown[]> = { [K in keyof T]: T[K] | undefined };
 type InferComponents<A extends Id[]> = { [K in keyof A]: InferComponent<A[K]> };
 
+type i53 = number
+type i24 = number
+type Ty =  i53[];
+type ArchetypeId = number
+type Column = unknown[];
+
+type ArchetypeRecord = {
+    count: number;
+    column: number;
+}
+
+export type Archetype = {
+    id: number;
+    types: Ty;
+    type: string;
+    entities: number[];
+    columns: Column[];
+    records: ArchetypeRecord[];
+}
+
 type Iter<T extends unknown[]> = IterableFunction<LuaTuple<[Entity, ...T]>>;
 
 export type CachedQuery<T extends unknown[]> = {
@@ -47,6 +67,12 @@ export type CachedQuery<T extends unknown[]> = {
 	 * Returns an iterator that produces a tuple of [Entity, ...queriedComponents].
 	 */
 	iter(): Iter<T>;
+
+	/**
+	 * Returns the archetype of the query
+	 * @returns An array of archetype of the query
+	 */
+	archetypes(): Archetype[];
 } & Iter<T>;
 
 export type Query<T extends unknown[]> = {
@@ -75,6 +101,12 @@ export type Query<T extends unknown[]> = {
 	 * @returns A new Query with the exclusion applied.
 	 */
 	without(...components: Id[]): Query<T>;
+
+	/**
+	 * Returns the archetype of the query
+	 * @returns An array of archetype of the query
+	 */
+	archetypes(): Archetype[];
 } & Iter<T>;
 
 export class World {


### PR DESCRIPTION
## Brief Description of your Changes.

Resolves #182 - Types for Archetypes when using query and cached query

## Impact of your Changes

Only typescript definition file is changed

## Tests Performed

Tested the types in my local machine

## Additional Comments