### PR TITLE
Remove entity type intersection

### DIFF
--- a/jecs.luau
+++ b/jecs.luau
@@ -2196,7 +2196,7 @@ function World.new()
 	return self
 end
 
-export type Entity<T = nil> = T
+export type Entity<T = unknown> = T
 
 export type Id<T = nil> =
     | Entity<T>

--- a/jecs.luau
+++ b/jecs.luau
@@ -2196,7 +2196,7 @@ function World.new()
 	return self
 end
 
-export type Entity<T = nil> = number & { __T: T }
+export type Entity<T = nil> = T
 
 export type Id<T = nil> =
     | Entity<T>


### PR DESCRIPTION
## Brief Description of your Changes.

It's currently impossible to typecheck the component and value arguments to `World:set` with the new solver because generic argument inference is greedy (calling `type f = <t>(x: t, y: t) -> ()` with `f(string, number)` will infer `t` as `string | number`. In the old solver the first argument `string` would be chosen for `t` and the second argument `number` would error.

Though I know all component types upfront and can call a type function to generate equivalent function overloads, it will still allow invalid arguments even if I pull the type from `__T`.

This change allows for a valid type function to be written for `set` by new solver users.

## Impact of your Changes

Values can be mistakenly passed as components, but this is inevitable assuming Jecs adopts generic constraints. Assertions could be added except in the case of `number` components.

## Tests Performed

Checked that Jecs typechecked, that basic usage with old solver typechecked the same way as before this change, and wrote a type function to replace `set` for personal use.