### PR TITLE
Bump Jabby v0.2.0-rc.9

### DIFF
--- a/demo/src/ReplicatedStorage/std/scheduler.luau
+++ b/demo/src/ReplicatedStorage/std/scheduler.luau
@@ -56,17 +56,21 @@ world:set(PreSimulation, Event, RunService.PreSimulation)
 world:add(PreAnimation, Phase)
 world:set(PreAnimation, Event, RunService.PreAnimation)
 
-table.insert(jabby.public, {
-	class_name = "World",
+jabby.register({
+	applet = jabby.applets.world,
 	name = "MyWorld",
+	configuration = {
 	world = world,
-	debug = Name,
-	entities = {},
+	},
 })
 
-jabby.public.updated = true
-
-table.insert(jabby.public, jabby_scheduler)
+jabby.register({
+	applet = jabby.applets.scheduler,
+	name = "Scheduler",
+	configuration = {
+		scheduler = jabby_scheduler,
+	},
+})
 
 if RunService:IsClient() then 
 	world:add(PreRender, Phase)

--- a/demo/wally.toml
+++ b/demo/wally.toml
@@ -5,4 +5,4 @@ registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 
 [dependencies]
-jabby = "alicesaidhi/jabby@0.2.0-rc.3"
+jabby = "alicesaidhi/jabby@0.2.0-rc.9"


### PR DESCRIPTION
## Description

The Demo game would error due to Wally uses Jabby `v0.2.0-rc.9` when the Demo game was still using old Jabby API. This pull request bumps Jabby's version and migrates the Demo code to the latest API.

## Impact

This PR fixes the broken Demo game, which allows users to actually learn and test out Jecs features while they await the new documentation.

## Tests Performed

I've ran the demo game while pinning Jabby to version `0.2.0-rc.3`, observed how it should run, and then tested the game with the changes in this PR. No changes in expected behavior were observed.

## Additional Comments

Marcus you broke mob movement, get that fixed...