### PR TITLE
Fix redundant checks in world_remove

### DIFF
--- a/jecs.luau
+++ b/jecs.luau
@@ -899,7 +899,7 @@ local function world_remove(world: World, entity: i53, id: i53)
 	end
 	local to = archetype_traverse_remove(world, id, from)
 
-	if from and not (from == to) then
+	if from ~= to then
 		local idr = world.component_index[id]
 		local on_remove = idr.hooks.on_remove
 		if on_remove then


### PR DESCRIPTION
## Brief Description of your Changes.

`world_remove` already early returns if the `from` archetype doesn't exist; however, it then proceeds to check for `from` a second time before calling `entity_move`. This PR removes that extra check and diffs the `to` and `from` archetypes using the `~=` operator instead of `not (from == to)`.

## Impact of your Changes

None.

## Tests Performed

None.