### PR TITLE
Fixed world:target() returning incorrect targets after deletion

### DIFF
--- a/jecs.luau
+++ b/jecs.luau
@@ -1113,11 +1113,11 @@ do
 		end
 
 		local delete = entity
-		local component_index = world.component_index
 		local archetypes: Archetypes = world.archetypes
-		local tgt = ECS_PAIR(EcsWildcard, delete)
-		local idr_t = component_index[tgt]
-		local idr = component_index[delete]
+		local component_index = world.component_index
+
+		local idr = component_index[entity]
+		local idr_t = component_index[ECS_PAIR(EcsWildcard, entity)]
 
 		if idr then
 			local flags = idr.flags
@@ -1152,21 +1152,16 @@ do
 
 		if idr_t then
 			for archetype_id in idr_t.columns do
-				local children = {}
 				local idr_t_archetype = archetypes[archetype_id]
-
 				local idr_t_types = idr_t_archetype.types
-
-				for _, child in idr_t_archetype.entities do
-					table.insert(children, child)
-				end
-
+				local children = table.clone(idr_t_archetype.entities)
 				local n = #children
 
 				for _, id in idr_t_types do
 					if not ECS_IS_PAIR(id) then
 						continue
 					end
+
 					local object = ecs_pair_second(world, id)
 					if object == delete then
 						local id_record = component_index[id]
@@ -1181,14 +1176,24 @@ do
 							local on_remove = id_record.hooks.on_remove
 							local to = archetype_traverse_remove(world, id, idr_t_archetype)
 							local empty = #to.types == 0
-							for i = n, 1, -1 do
-								local child = children[i]
-								if on_remove then
+
+							if on_remove then
+								for i = n, 1, -1 do
+									local child = children[i]
 									on_remove(child)
+
+									if not empty then
+										local r = sparse_array[ECS_ENTITY_T_LO(child)]
+										entity_move(entity_index, child, r, to)
+									end
 								end
-								local r = sparse_array[ECS_ENTITY_T_LO(child)]
-								if not empty then
-									entity_move(entity_index, child, r, to)
+							else
+								if not empty then -- no on_remove hook set; fast path
+									for i = n, 1, -1 do
+										local child = children[i]
+										local r = sparse_array[ECS_ENTITY_T_LO(child)]
+										entity_move(entity_index, child, r, to)
+									end
 								end
 							end
 						end

--- a/jecs.luau
+++ b/jecs.luau
@@ -1113,11 +1113,11 @@ do
 		end
 
 		local delete = entity
-		local archetypes: Archetypes = world.archetypes
 		local component_index = world.component_index
-
-		local idr = component_index[entity]
-		local idr_t = component_index[ECS_PAIR(EcsWildcard, entity)]
+		local archetypes: Archetypes = world.archetypes
+		local tgt = ECS_PAIR(EcsWildcard, delete)
+		local idr_t = component_index[tgt]
+		local idr = component_index[delete]
 
 		if idr then
 			local flags = idr.flags

--- a/jecs.luau
+++ b/jecs.luau
@@ -1154,6 +1154,8 @@ do
 			for archetype_id in idr_t.columns do
 				local idr_t_archetype = archetypes[archetype_id]
 				local idr_t_types = idr_t_archetype.types
+				local to = idr_t_archetype
+
 				local children = table.clone(idr_t_archetype.entities)
 				local n = #children
 
@@ -1163,28 +1165,30 @@ do
 					end
 
 					local object = ecs_pair_second(world, id)
-					if object == delete then
-						local id_record = component_index[id]
-						local flags = id_record.flags
-						local flags_delete_mask: number = bit32.band(flags, ECS_ID_DELETE)
-						if flags_delete_mask ~= 0 then
-							for i = n, 1, -1 do
-								world_delete(world, children[i])
+					if object ~= delete then
+						continue
+					end
+
+					local id_record = component_index[id]
+					local flags = id_record.flags
+					local flags_delete_mask: number = bit32.band(flags, ECS_ID_DELETE)
+					if flags_delete_mask ~= 0 then
+						for i = n, 1, -1 do
+							world_delete(world, children[i])
+						end
+						break
+					else
+						local on_remove = id_record.hooks.on_remove
+						to = archetype_traverse_remove(world, id, to)
+						local empty = #to.types == 0
+						for i = n, 1, -1 do
+							local child = children[i]
+							if on_remove then
+								on_remove(child)
 							end
-							break
-						else
-							local on_remove = id_record.hooks.on_remove
-							local to = archetype_traverse_remove(world, id, idr_t_archetype)
-							local empty = #to.types == 0
-							for i = n, 1, -1 do
-								local child = children[i]
-								if on_remove then
-									on_remove(child)
-								end
-								if not empty then
-									local r = sparse_array[ECS_ENTITY_T_LO(child)]
-									entity_move(entity_index, child, r, to)
-								end
+							if not empty then
+								local r = sparse_array[ECS_ENTITY_T_LO(child)]
+								entity_move(entity_index, child, r, to)
 							end
 						end
 					end

--- a/jecs.luau
+++ b/jecs.luau
@@ -1176,24 +1176,14 @@ do
 							local on_remove = id_record.hooks.on_remove
 							local to = archetype_traverse_remove(world, id, idr_t_archetype)
 							local empty = #to.types == 0
-
-							if on_remove then
-								for i = n, 1, -1 do
-									local child = children[i]
+							for i = n, 1, -1 do
+								local child = children[i]
+								if on_remove then
 									on_remove(child)
-
-									if not empty then
-										local r = sparse_array[ECS_ENTITY_T_LO(child)]
-										entity_move(entity_index, child, r, to)
-									end
 								end
-							else
-								if not empty then -- no on_remove hook set; fast path
-									for i = n, 1, -1 do
-										local child = children[i]
-										local r = sparse_array[ECS_ENTITY_T_LO(child)]
-										entity_move(entity_index, child, r, to)
-									end
+								if not empty then
+									local r = sparse_array[ECS_ENTITY_T_LO(child)]
+									entity_move(entity_index, child, r, to)
 								end
 							end
 						end

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -1333,6 +1333,26 @@ TEST("world:target", function()
 
 		CHECK(i == 10)
 	end
+
+	do CASE("should return correct targets after deletion") -- ISSUE #207
+		local world = jecs.World.new()
+
+		local Attacks = world:component()
+		local Eats = world:component()
+		local a = world:entity()
+		local b = world:entity()
+		local c = world:entity()
+
+		world:add(a, jecs.pair(Attacks, b))
+		world:add(a, jecs.pair(Attacks, c))
+		world:add(a, jecs.pair(Eats, c))
+		world:add(a, jecs.pair(Eats, b))
+		world:delete(c)
+
+		CHECK(world:target(a, Attacks, 0) == b)
+		CHECK(not world:target(a, Attacks, 1))
+		CHECK(not world:target(a, Attacks, 2))
+	end
 end)
 
 TEST("world:contains", function()


### PR DESCRIPTION
## Brief Description of your Changes.

Fixes #207, a rare bug where world:target() can return incorrect ids after an entity in a pair is deleted if certain conditions are met. Also includes a minor optimization for world:delete()'s cleanup of relationships.

## Impact of your Changes

Bug fix.

## Tests Performed

None.