### PR TITLE
Change OnSet to OnChange in type definitions for typescript

### DIFF
--- a/jecs.d.ts
+++ b/jecs.d.ts
@@ -258,7 +258,7 @@ export function pair_second<P, O>(world: World, p: Pair<P, O>): Entity<O>;
 
 export declare const OnAdd: Entity<(e: Entity) => void>;
 export declare const OnRemove: Entity<(e: Entity) => void>;
-export declare const OnSet: Entity<(e: Entity, value: unknown) => void>;
+export declare const OnChange: Entity<(e: Entity, value: unknown) => void>;
 export declare const ChildOf: Tag;
 export declare const Wildcard: Entity;
 export declare const w: Entity;


### PR DESCRIPTION
## Brief Description of your Changes.

I changed the component OnSet's name in the type definition file from OnSet to OnChange due to the luau file replacing OnSet with OnChange 

## Impact of your Changes
There's none.

## Tests Performed
This doesn't have any tests and doesn't need any.