### PR TITLE
Fix duplicated 'Luau/TypeScript' in documentation

### DIFF
--- a/docs/learn/concepts/component-traits.md
+++ b/docs/learn/concepts/component-traits.md
@@ -152,6 +152,8 @@ world.add(loot, pair(OwnedBy, player));
 world.delete(player);
 ```
 
+:::
+
 ### (OnDeleteTarget, Delete)
 
 ::: code-group


### PR DESCRIPTION
## Brief Description of your Changes.

Closed ::: code-group with ::: in component-traits.md below (OnDeleteTarget, Remove) to fix the duplicated 'luau/typescript'

## Impact of your Changes

This is a documentation change, and shouldn't change jecs

## Additional Comments

I used the github web editor, which sometimes does some weird newline stuff
If there any issues, feel free to let me know. Thank you.