### PR TITLE
Fixed jecs addon repository links

### DIFF
--- a/docs/learn/concepts/addons.md
+++ b/docs/learn/concepts/addons.md
@@ -8,17 +8,17 @@ A collection of third-party jecs addons made by the community. If you would like
 
 A jecs debugger with a string-based query language and entity editing capabilities.
 
-## [jecs_entity_visualiser](https://github.com/Ukendio/jecs/tree/main/addons/entity_visualiser)
+## [jecs_entity_visualiser](https://github.com/Ukendio/jecs/blob/main/addons/entity_visualiser.luau)
 
 A simple entity and component visualiser in the output
 
-## [jecs_lifetime_tracker](https://github.com/Ukendio/jecs/tree/main/addons/lifetime_tracker)
+## [jecs_lifetime_tracker](https://github.com/Ukendio/jecs/blob/main/addons/lifetime_tracker.luau)
 
 A tool for inspecting entity lifetimes
 
 # Helpers
 
-## [jecs_observers](https://github.com/Ukendio/jecs/tree/main/addons/observers)
+## [jecs_observers](https://github.com/Ukendio/jecs/blob/main/addons/observers.luau)
 
 Observers for queries and signals for components
 


### PR DESCRIPTION
Fixing the link for jecs_observers (and other non-existent but I'm guessing future addons) on the jecs docs