### PR TITLE
Docs/hooks set order warning

### DIFF
--- a/docs/learn/concepts/component-traits.md
+++ b/docs/learn/concepts/component-traits.md
@@ -14,6 +14,10 @@ A (component) ID can be marked with `Tag´ in which the component will never con
 
 Hooks are part of the "interface" of a component. You could consider hooks as the counterpart to OOP methods in ECS. They define the behavior of a component, but can only be invoked through mutations on the component data. You can only configure a single `OnAdd`, `OnRemove` and `OnSet` hook per component, just like you can only have a single constructor and destructor.
 
+::: warning
+Hooks must be added to a component before it is used with other entities/components for them to take effect.
+:::
+
 ## Examples
 
 ::: code-group

--- a/docs/learn/concepts/component-traits.md
+++ b/docs/learn/concepts/component-traits.md
@@ -15,7 +15,7 @@ A (component) ID can be marked with `Tag´ in which the component will never con
 Hooks are part of the "interface" of a component. You could consider hooks as the counterpart to OOP methods in ECS. They define the behavior of a component, but can only be invoked through mutations on the component data. You can only configure a single `OnAdd`, `OnRemove` and `OnSet` hook per component, just like you can only have a single constructor and destructor.
 
 ::: warning
-Hooks must be added to a component before it is used with other entities/components for them to take effect.
+Hooks, added to a component that has already been added to other entities/components, will not be called.
 :::
 
 ## Examples


### PR DESCRIPTION
## Brief Description of your Changes.

The purpose of this PR is to make clear the order in which hooks must be added to a component.

## Impact of your Changes

* Added a warning to the concepts/component-traits hooks section, on the order in which hooks must be added.

## Tests Performed

Site was manually built locally to ensure correct rendering.
Upon this PR being opened, a release build of the website will be deployed onto GitHub Pages. This will serve as a test to ensure correct rendering.

## Additional Comments

None