### PR TITLE
fix: allow world.add() to accept component, add world.entity overload

### DIFF
--- a/jecs.d.ts
+++ b/jecs.d.ts
@@ -120,6 +120,7 @@ export class World {
 	 * @returns An entity (Tag) with no data.
 	 */
 	entity(): Tag;
+	entity(id: number): Tag;
 
 	/**
 	 * Creates a new entity in the first 256 IDs, typically used for static

--- a/jecs.d.ts
+++ b/jecs.d.ts
@@ -149,7 +149,7 @@ export class World {
 	 * @param entity The target entity.
 	 * @param component The component (or tag) to add.
 	 */
-	add(entity: Entity, component: Id): void;
+	add<C>(entity: Entity, component: undefined extends InferComponent<C> ? C : Id<undefined>): void;
 
 	/**
 	 * Assigns a value to a component on the given entity.

--- a/jecs.d.ts
+++ b/jecs.d.ts
@@ -148,7 +148,7 @@ export class World {
 	 * @param entity The target entity.
 	 * @param component The component (or tag) to add.
 	 */
-	add(entity: Entity, component: Id<undefined>): void;
+	add(entity: Entity, component: Id): void;
 
 	/**
 	 * Assigns a value to a component on the given entity.

--- a/jecs.d.ts
+++ b/jecs.d.ts
@@ -120,7 +120,7 @@ export class World {
 	 * @returns An entity (Tag) with no data.
 	 */
 	entity(): Tag;
-	entity(id: number): Tag;
+	entity<T extends Entity>(id: T): InferComponent<T> extends undefined ? Tag : T;
 
 	/**
 	 * Creates a new entity in the first 256 IDs, typically used for static

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@rbxts/jecs",
-	"version": "0.6.1",
+	"version": "0.6.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@rbxts/jecs",
-			"version": "0.6.1",
+			"version": "0.6.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@rbxts/compiler-types": "^2.3.0-types.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@rbxts/jecs",
-	"version": "0.6.0-rc.1",
+	"version": "0.6.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@rbxts/jecs",
-			"version": "0.6.0-rc.1",
+			"version": "0.6.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@rbxts/compiler-types": "^2.3.0-types.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rbxts/jecs",
-	"version": "0.6.1",
+	"version": "0.6.0",
 	"description": "Stupidly fast Entity Component System",
 	"main": "jecs.luau",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rbxts/jecs",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"description": "Stupidly fast Entity Component System",
 	"main": "jecs.luau",
 	"repository": {


### PR DESCRIPTION
## Brief Description of your Changes.
This is a typescript definition change to allow feces, a fast entity component export system to work in typescript. My current approach for the typescript definitions are. However, when using the following code it errors. Although this isn't a good practice, but its up to personal preference to choose component as tag or entity as tag. In the feces source code, they use jecs's component for replicating instead of entity because of its design.

Feces typescript definitions source code
```ts
type PlayerObject = Player | Player[] | ((arg: Player) => boolean);
...
replicated: Entity<PlayerObject>;
```
Example attempt of using the type
```ts
const mock: Player = 1 as any;
world.add(e, replicated); //this will error
world.set(e, replicated, mock);
```
To be more clear, it a example code would be this
```ts
const world = new World();
const component = world.component()
const tag = world.entity()
const entity = world.entity()

world.add(entity, tag)
world.add(entity, component) // this will error
```

## Impact of your Changes
This will allow @rbxts/feces to work in with typescript union types and allow components to be used in `world.add` with components

## Tests Performed
N/A
