### PR TITLE
Fix hooks types

### DIFF
--- a/jecs.luau
+++ b/jecs.luau
@@ -2651,9 +2651,9 @@ return {
 	meta = (ECS_META :: any) :: <T>(id: Entity, id: Id<T>, value: T) -> Entity<T>,
 	is_tag = (ecs_is_tag :: any) :: <T>(World, Id<T>) -> boolean,
 	
-    OnAdd = EcsOnAdd :: Entity<(entity: Entity, id: Id, data: any) -> ()>,
+    OnAdd = EcsOnAdd :: Entity<<T>(entity: Entity, id: Id<T>, data: T) -> ()>,
 	OnRemove = EcsOnRemove :: Entity<(entity: Entity, id: Id) -> ()>,
-	OnChange = EcsOnChange :: Entity<(entity: Entity, id: Id, data: any) -> ()>,
+	OnChange = EcsOnChange :: Entity<<T>(entity: Entity, id: Id<T>, data: T) -> ()>,
 	ChildOf = EcsChildOf :: Entity,
 	Component = EcsComponent :: Entity,
 	Wildcard = EcsWildcard :: Entity,

--- a/jecs.luau
+++ b/jecs.luau
@@ -2650,10 +2650,10 @@ return {
 	tag = (ECS_TAG :: any) :: <T>() -> Entity<T>,
 	meta = (ECS_META :: any) :: <T>(id: Entity, id: Id<T>, value: T) -> Entity<T>,
 	is_tag = (ecs_is_tag :: any) :: <T>(World, Id<T>) -> boolean,
-
-	OnAdd = EcsOnAdd :: Entity<(entity: Entity) -> ()>,
-	OnRemove = EcsOnRemove :: Entity<(entity: Entity) -> ()>,
-	OnChange = EcsOnChange :: Entity<(entity: Entity, data: any) -> ()>,
+	
+    OnAdd = EcsOnAdd :: Entity<(entity: Entity, id: Id, data: any) -> ()>,
+	OnRemove = EcsOnRemove :: Entity<(entity: Entity, id: Id) -> ()>,
+	OnChange = EcsOnChange :: Entity<(entity: Entity, id: Id, data: any) -> ()>,
 	ChildOf = EcsChildOf :: Entity,
 	Component = EcsComponent :: Entity,
 	Wildcard = EcsWildcard :: Entity,


### PR DESCRIPTION
## Brief Description of your Changes.

The hook types in `OnAdd` `OnChange`, `OnRemove` are no longer correct in 0.6.0. This pr fixes them

## Impact of your Changes

No impact, only types were changed

## Tests Performed

N/A

## Additional Comments

N/A