### PR TITLE
Fix typo in observers addon

### DIFF
--- a/addons/observers.luau
+++ b/addons/observers.luau
@@ -7,7 +7,7 @@ type Observer = {
 
 type Monitor = {
 	callback: (jecs.Entity, jecs.Entity) -> (),
-	queyr: jecs.Query<any>
+	query: jecs.Query<any>
 }
 
 export type PatchedWorld = jecs.World & {


### PR DESCRIPTION
## Brief Description of your Changes.
Fixes a typo in the Monitor type of the observers addon

## Impact of your Changes
Jecs users won't have to fix this typo themselves when using the observer addon.

## Tests Performed
Tests not necessary
