### PR TITLE
Add ECS_PAIR_* functions to typings

### DIFF
--- a/jecs.d.ts
+++ b/jecs.d.ts
@@ -289,6 +289,9 @@ export function pair_first<P, O>(world: World, p: Pair<P, O>): Entity<P>;
  */
 export function pair_second<P, O>(world: World, p: Pair<P, O>): Entity<O>;
 
+export function ECS_PAIR_FIRST<P, O>(pair: Pair<P, O>): Entity<P>;
+export function ECS_PAIR_SECOND<P, O>(pair: Pair<P, O>): Entity<O>;
+
 type StatefulHook = Entity<<T>(e: Entity<T>, id: Id<T>, data: T) => void> & {
 	readonly __nominal_StatefulHook: unique symbol,
 }


### PR DESCRIPTION
## Brief Description of your Changes.

Adds `ECS_PAIR_FIRST` and `ECS_PAIR_SECOND` to the typings.

## Impact of your Changes

This allows easy extraction of entity IDs from a pair without asserting the entities are alive.

## Tests Performed

Ran the functions after a successful compilation.

## Additional Comments

N/A