### PR TITLE
Fix regression with set overloads

### DIFF
--- a/jecs.d.ts
+++ b/jecs.d.ts
@@ -152,14 +152,6 @@ export class World {
 	add<C>(entity: Entity, component: undefined extends InferComponent<C> ? C : Id<undefined>): void;
 	
 	/**
-	 * Assigns a value to a component on the given entity.
-	 * @param entity The target entity.
-	 * @param component The component definition (could be a Pair or Entity).
-	 * @param value The value to store with that component.
-	 */
-	set<T>(entity: Entity, component: Id<T>, value: T): void;
-
-	/**
 	 * Installs a hook on the given component.
 	 * @param component The target component.
 	 * @param hook The hook to install.
@@ -173,6 +165,13 @@ export class World {
 	 * @param value The hook callback.
 	 */
 	set<T>(component: Entity<T>, hook: StatelessHook, value: (e: Entity<T>, id: Id<T>) => void): void;
+	/**
+	 * Assigns a value to a component on the given entity.
+	 * @param entity The target entity.
+	 * @param component The component definition (could be a Pair or Entity).
+	 * @param value The value to store with that component.
+	 */
+	set<T>(entity: Entity, component: Id<T>, value: T): void;
 
 	/**
 	 * Cleans up the world by removing empty archetypes and rebuilding the archetype collections.


### PR DESCRIPTION
## Brief Description of your Changes.

Unfortunately, when testing the changes I made to the overloads in #237, this issue went under the radar and caused the hook overloads to stop functioning. This PR reverts the ordering change, placing the "main" set behaviour once again last.

## Impact of your Changes

Fixes the hook overloads no longer working. This also means that the benefits #237 introduced (e.g. the hook overloads being displayed after the primary one) are unfortunately gone.

## Tests Performed

Compiled a project with the fix (hopefully nothing goes under the radar again...)

## Additional Comments

N/A