### PR TITLE
Fix regression with set

### DIFF
--- a/jecs.d.ts
+++ b/jecs.d.ts
@@ -165,7 +165,7 @@ export class World {
 	 * @param component The component definition (could be a Pair or Entity).
 	 * @param value The value to store with that component.
 	 */
-	set<T>(entity: Entity, component: Id<T>, value: T): void;
+	set<E extends Id<unknown>>(entity: Entity, component: E, value: InferComponent<E>): void;
 
 	/**
 	 * Cleans up the world by removing empty archetypes and rebuilding the archetype collections.


### PR DESCRIPTION
## Brief Description of your Changes.

Fixes a regression with set's typings which allowed types related by inheritance, although incorrectly, to be set.
For example, `PVinstance` inherits from `Instance` and due to this regression you were able to set an `Instance` as a value of `PVInstance`.

## Impact of your Changes

Ensures components' values are correct.

## Tests Performed

Compiled a project with the corrected typings.

## Additional Comments

N/A