### PR TITLE
Fix addons, monitor emplace should have EcsOnAdd

### DIFF
--- a/addons/ob.luau
+++ b/addons/ob.luau
@@ -146,12 +146,13 @@ local function monitors_new<T...>(
 			entity_index, entity :: any) :: jecs.Record
 
 		local archetype = r.archetype
+		local EcsOnAdd = jecs.OnAdd :: jecs.Id
 
 		if archetypes[archetype.id] then
 			i += 1
 			entities[i] = entity
 			if callback ~= nil then
-				callback(entity, id, value)
+				callback(entity, EcsOnAdd, value)
 			end
 		end
 	end


### PR DESCRIPTION
## Brief Description of your Changes.
The monitor addon in the addons/ob.luau should return the jecs.OnAdd event when a query is matched. Currently it provides `id` which does not align with `removed` function's behaviour.

## Impact of your Changes
Monitor addon now returns the event in 2nd parameter on the callback function

## Tests Performed
N/A

## Additional Comments
N/A