### PR TITLE
Correct Archetype field types

### DIFF
--- a/jecs.d.ts
+++ b/jecs.d.ts
@@ -49,9 +49,9 @@ export type Column<T> = T[];
 
 export type Archetype<T extends Id[]> = {
 	id: number;
-	types: number[];
+	types: Entity[];
 	type: string;
-	entities: number[];
+	entities: Entity[];
 	columns: Column<unknown>[];
 	columns_map: { [K in T[number]]: Column<InferComponent<K>> };
 };


### PR DESCRIPTION
## Brief Description of your Changes.

Corrects the `types` and `entities` fields to be arrays of `Entity`, not `number`.

## Impact of your Changes

Values will now be easily usable as entity IDs.

## Tests Performed

Compiled a game with the changes.

## Additional Comments

N/A