### PR TITLE
Allow tags in bulk_insert

### DIFF
--- a/jecs.d.ts
+++ b/jecs.d.ts
@@ -338,10 +338,12 @@ export type ComponentRecord = {
 
 export function component_record(world: World, id: Id): ComponentRecord;
 
+type TagToUndefined<T> = T extends TagDiscriminator ? undefined : T
+
 export function bulk_insert<const C extends Id[]>(
 	world: World,
 	entity: Entity,
 	ids: C,
-	values: InferComponents<C>,
+	values: { [K in keyof C]: TagToUndefined<InferComponent<C[K]>> },
 ): void;
 export function bulk_remove(world: World, entity: Entity, ids: Id[]): void;


### PR DESCRIPTION
## Brief Description of your Changes.

Allows `bulk_insert`ing tags by using `undefined` as their value.

## Impact of your Changes

Makes tags once again `bulk_insert`able.

## Tests Performed

Ensured tags and components work with `bulk_insert`.

## Additional Comments

N/A