### PR TITLE
Record types

### DIFF
--- a/jecs.d.ts
+++ b/jecs.d.ts
@@ -345,3 +345,11 @@ export function bulk_insert<const C extends Id[]>(
 	values: InferComponents<C>,
 ): void;
 export function bulk_remove(world: World, entity: Entity, ids: Id[]): void;
+
+export type EntityRecord<E extends Entity> = {
+	archetype: Archetype<[E]>,
+	row: number,
+	dense: number,
+};
+
+export function record<E extends Entity>(world: World, entity: E): EntityRecord<E>;

--- a/jecs.d.ts
+++ b/jecs.d.ts
@@ -346,10 +346,10 @@ export function bulk_insert<const C extends Id[]>(
 ): void;
 export function bulk_remove(world: World, entity: Entity, ids: Id[]): void;
 
-export type EntityRecord<E extends Entity> = {
-	archetype: Archetype<[E]>,
+export type EntityRecord<T extends Id[]> = {
+	archetype: Archetype<T>,
 	row: number,
 	dense: number,
 };
 
-export function record<E extends Entity>(world: World, entity: E): EntityRecord<E>;
+export function record<T extends Id[] = []>(world: World, entity: Entity): EntityRecord<T>;


### PR DESCRIPTION
## Brief Description of your Changes.

Adds typings for the `record` function. Allows typing the Archetype by using a generic, e.g. `record<[typeof MyCt]>(world, entity)`.

## Impact of your Changes

Allows simple usage of the function from roblox-ts.

## Tests Performed

Checked the types match what is returned.

## Additional Comments

N/A