### PR TITLE
Fix bulk_insert with moving archetypes

### DIFF
--- a/jecs.luau
+++ b/jecs.luau
@@ -2110,15 +2110,13 @@ local function ecs_bulk_insert(world: world, entity: i53, ids: { i53 }, values: 
 		local dst_types = ids
 		local to = archetype_ensure(world, dst_types)
 		new_entity(entity, r, to)
-		local row = r.row
-		local columns_map = to.columns_map
 		for i, id in ids do
 			local value = values[i]
 			local cdr = component_index[id]
 
 			local on_add = cdr.on_add
 			if value then
-				columns_map[id][row] = value
+				r.archetype.columns_map[id][r.row] = value
 				if on_add then
 					on_add(entity, id, value :: any)
 				end
@@ -2148,12 +2146,10 @@ local function ecs_bulk_insert(world: world, entity: i53, ids: { i53 }, values: 
 	end
 
 	local to = archetype_ensure(world, dst_types)
-	local columns_map = to.columns_map
 
 	if from ~= to then
 		entity_move(entity_index, entity, r, to)
 	end
-	local row = r.row
 
 	for i, set in emplaced do
 		local id = ids[i]
@@ -2164,7 +2160,7 @@ local function ecs_bulk_insert(world: world, entity: i53, ids: { i53 }, values: 
 		local on_add = idr.on_add
 
 		if value ~= nil then
-			columns_map[id][row] = value
+			r.archetype.columns_map[id][r.row] = value
 			local on_change = idr.on_change
 			local hook = if set then on_change else on_add
 			if hook then

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -331,6 +331,37 @@ TEST("bulk", function()
 		CHECK(world:has(e, c1, c2, c3))
 		CHECK(count == 3)
 	end
+
+	do CASE "Should work with hooks moving archetypes without previous"
+		local world = jecs.world()
+		local c1, c2, c3 = world:component(), world:component(), world:component()
+		
+		world:added(c1, function(e)
+			world:set(e, c3, "hello")
+		end)
+		
+		local e = world:entity()
+		jecs.bulk_insert(world, e, {c1,c2}, {true, 123})
+		CHECK(world:get(e, c1) == true)
+		CHECK(world:get(e, c2) == 123)
+		CHECK(world:get(e, c3) == "hello")
+	end
+
+	do CASE "Should work with hooks moving archetypes with previous"
+		local world = jecs.world()
+		local c1, c2, c3 = world:component(), world:component(), world:component()
+		
+		world:added(c1, function(e)
+			world:set(e, c3, "hello")
+		end)
+		
+		local e = world:entity()
+		world:add(e, world:entity())
+		jecs.bulk_insert(world, e, {c1,c2}, {true, 123})
+		CHECK(world:get(e, c1) == true)
+		CHECK(world:get(e, c2) == 123)
+		CHECK(world:get(e, c3) == "hello")
+	end
 end)
 
 TEST("repro", function()

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -332,7 +332,7 @@ TEST("bulk", function()
 		CHECK(count == 3)
 	end
 
-	do CASE "Should work with hooks moving archetypes without previous"
+	do CASE "Should bulk add with hooks moving archetypes without previous"
 		local world = jecs.world()
 		local c1, c2, c3 = world:component(), world:component(), world:component()
 		
@@ -347,7 +347,7 @@ TEST("bulk", function()
 		CHECK(world:get(e, c3) == "hello")
 	end
 
-	do CASE "Should work with hooks moving archetypes with previous"
+	do CASE "Should bulk add with hooks moving archetypes with previous"
 		local world = jecs.world()
 		local c1, c2, c3 = world:component(), world:component(), world:component()
 		


### PR DESCRIPTION
## Brief Description of your Changes.

Fixes `bulk_insert` breaking when the archetype moves due to hooks.

## Impact of your Changes

Values will now get set as expected.

## Tests Performed

Tests included in the PR.

## Additional Comments

N/A