### PR TITLE
Fix `bulk_insert` not ensuring that archetype ids are sorted

### DIFF
--- a/jecs.luau
+++ b/jecs.luau
@@ -2050,7 +2050,9 @@ local function ecs_bulk_insert(world: world, entity: i53, ids: { i53 }, values: 
 	local from = r.archetype
 	local component_index = world.component_index
 	if not from then
-		local dst_types = ids
+		local dst_types = table.clone(ids)
+		table.sort(dst_types)
+
 		local to = archetype_ensure(world, dst_types)
 		new_entity(entity, r, to)
 		local ROOT_ARCHETYPE = world.ROOT_ARCHETYPE

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -330,6 +330,20 @@ TEST("bulk", function()
 		CHECK(world:get(e, c2) == 123)
 		CHECK(world:get(e, c3) == "hello")
 	end
+
+	do CASE "Should ensure archetype ids are sorted"
+		local world = jecs.world()
+		local c1, c2, c3 = world:component(), world:component(), world:component()
+
+		local e = world:entity()
+		jecs.bulk_insert(world, e, { c2, c1 }, { 2, 1 })
+		jecs.bulk_insert(world, e, { c1 }, { 1 })
+		world:set(e, c3, 3)
+
+		CHECK(world:get(e, c1) == 1)
+		CHECK(world:get(e, c2) == 2)
+		CHECK(world:get(e, c3) == 3)
+	end
 end)
 
 TEST("repro", function()


### PR DESCRIPTION
## Brief Description of your Changes.

Changed `bulk_insert` to sort the ids table passed when the entity doesn't have an existing archetype.

This change fixes an edge case with `bulk_insert` that can lead to an archetype having multiple columns for the same id. The issue stems from `bulk_insert` not sorting the passed ids when creating a new archetype for an entity without an archetype, subsequent calls to `bulk_insert` can then create a new archetype containing the id twice (twice in the types array, and with two columns for it). Since the second column is empty any subsequent archetype moves of the entity will cause the data of the id to be erased. This duplication specifically happens due to `bulk_insert`'s reliance on `find_insert`, which expects a **sorted** ids array, to find where in the archetypes ids array to insert an id.

Internally the interaction looks something like this:
* bulk_insert is called on e0 with ids { 2, 1 }, an archetype with ids { 2, 1 } is created
* bulk_insert is called on e0 with ids { 1 }, an archetype with ids { 1, 2, 1} is created
* the entity moves archetypes due to some other piece of code, the move process first copies the correct column for id 1 then copies the duplicate column for id 1 effectively erasing the data

## Impact of your Changes

There might be a minimal performance degradation in the case of using `bulk_insert` to initialize a freshly created entity due to the use of `table.clone` (to avoid mutating the passed ids table) and `table.sort`.

## Tests Performed

I added a new test case for the issue and ran the already existing tests to confirm there haven't been any breaking changes.