### PR TITLE
Make World.contains a number->Entity typeguard

### DIFF
--- a/jecs.d.ts
+++ b/jecs.d.ts
@@ -237,6 +237,12 @@ export class World {
 	contains(entity: Entity): boolean;
 
 	/**
+	 * Checks if an entity exists in the world.
+	 * @param entity The entity to verify.
+	 */
+	contains(entity: number): entity is Entity;
+
+	/**
 	 * Checks if an entity with the given ID is currently alive, ignoring its generation.
 	 * @param entity The entity to verify.
 	 * @returns boolean true if any entity with the given ID exists (ignoring generation), false otherwise


### PR DESCRIPTION
## Brief Description of your Changes.

Makes `World.contains` a typeguard for normal numbers to become `Entity`-ies.

## Impact of your Changes

Simplifies checking whether networked IDs are valid entities.

## Tests Performed

Compiled a project with the change.

## Additional Comments

N/A