### PR TITLE
Make optionals not required in bulk_insert

### DIFF
--- a/jecs.d.ts
+++ b/jecs.d.ts
@@ -350,13 +350,19 @@ export type ComponentRecord = {
 export function component_record(world: World, id: Id): ComponentRecord;
 
 type TagToUndefined<T> = T extends TagDiscriminator ? undefined : T
-type TrimUndefined<T extends unknown[]> = T extends [...infer R, undefined] ? TrimUndefined<R> : T
+type TrimOptional<T extends unknown[]> = T extends [...infer L, infer R] 
+	? unknown extends R 
+		? L | T | TrimOptional<L> 
+		: R extends undefined
+			? L | T | TrimOptional<L>
+			: T
+	: T
 
 export function bulk_insert<const C extends Id[]>(
 	world: World,
 	entity: Entity,
 	ids: C,
-	values: [...TrimUndefined<{ [K in keyof C]: TagToUndefined<InferComponent<C[K]>> }>, ...undefined[]],
+	values: TrimOptional<{ [K in keyof C]: TagToUndefined<InferComponent<C[K]>> }>,
 ): void;
 export function bulk_remove(world: World, entity: Entity, ids: Id[]): void;
 

--- a/jecs.d.ts
+++ b/jecs.d.ts
@@ -350,12 +350,13 @@ export type ComponentRecord = {
 export function component_record(world: World, id: Id): ComponentRecord;
 
 type TagToUndefined<T> = T extends TagDiscriminator ? undefined : T
+type TrimUndefined<T extends unknown[]> = T extends [...infer R, undefined] ? TrimUndefined<R> : T
 
 export function bulk_insert<const C extends Id[]>(
 	world: World,
 	entity: Entity,
 	ids: C,
-	values: { [K in keyof C]: TagToUndefined<InferComponent<C[K]>> },
+	values: [...TrimUndefined<{ [K in keyof C]: TagToUndefined<InferComponent<C[K]>> }>, ...undefined[]],
 ): void;
 export function bulk_remove(world: World, entity: Entity, ids: Id[]): void;
 


### PR DESCRIPTION
## Brief Description of your Changes.

Makes using `bulk_insert` less annoying by not requiring `undefined` to be passed in explicitly when at the end. This change also covers `unknown` to apply to pairs from queries, such as `pair(MyTag, queriedEntity)`.

## Impact of your Changes

Makes `bulk_insert` more user-friendly.

## Tests Performed

Compiled a project.

## Additional Comments

N/A