### PR TITLE
chore: fix aliases paths in luau manifest

### DIFF
--- a/.luaurc
+++ b/.luaurc
@@ -1,10 +1,10 @@
 {
     "aliases": {
-        "jecs": "jecs",
-        "testkit": "tools/testkit",
-        "mirror": "mirror",
-        "tools": "tools",
-        "addons": "addons"
+        "jecs": "./jecs",
+        "testkit": "./tools/testkit",
+        "mirror": "./mirror",
+        "tools": "./tools",
+        "addons": "./addons"
     },
     "languageMode": "strict"
 }


### PR DESCRIPTION
**why**
using luau [0.695](https://github.com/luau-lang/luau/releases/tag/0.695), which is the current latest, causes errors with requires aliases. this pr fixes that.

<img width="704" height="421" alt="image" src="https://github.com/user-attachments/assets/7b81acb8-62e0-4f45-bdd0-e78e1f3a77f6" />

