### PR TITLE
docs: add Observers to API navigation and fix import path

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -21,6 +21,7 @@ export default defineConfig({
 						{ text: "jecs", link: "/api/jecs" },
 						{ text: "World", link: "/api/world" },
 						{ text: "Query", link: "/api/query" },
+						{ text: "Observers", link: "/api/observers" },
 					],
 				},
 			],

--- a/docs/api/observers.md
+++ b/docs/api/observers.md
@@ -8,7 +8,7 @@ The observers addon is included with jecs and can be imported directly:
 
 ```luau
 local jecs = require(path/to/jecs)
-local observers_add = require(path/to/jecs/addons/observers)
+local observers_add = require(path/to/jecs/addons/ob)
 
 local world = observers_add(jecs.world())
 ```


### PR DESCRIPTION
Update the VitePress config to include Observers in the API navigation menu. Fix the import path in the Observers documentation.
