### PR TITLE
Upload luau file to releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,7 @@ jobs:
                   name: Jecs ${{ github.ref_name }}
                   files: |
                       jecs.rbxm
+                      jecs.luau
 
     publish:
         name: Publish


### PR DESCRIPTION
## Brief Description of your Changes.

Release workflow now uploads `jecs.luau` alongside `jecs.rbxm`, just as an easy way to download the specific version of the luau file for each release.

## Tests Performed

looked at the docs for the create release action used to find how to provide multiple files