### PR TITLE
Update TS Types to include query.has and others

### DIFF
--- a/src/jecs.d.ts
+++ b/src/jecs.d.ts
@@ -79,14 +79,6 @@ export type CachedQuery<T extends Id[]> = {
 	archetypes(): Archetype<T>[];
 
 	has(entity: Entity): boolean;
-
-	ids: Id<any>[];
-
-	filter_with?: Id<any>[];
-
-	filter_without?: Id<any>[];
-
-	archetypes_map: Map<number, number>;
 } & Iter<T>;
 
 export type Query<T extends Id[]> = {
@@ -123,12 +115,6 @@ export type Query<T extends Id[]> = {
 	archetypes(): Archetype<T>[];
 
 	has(entity: Entity): boolean;
-
-	ids: Id<any>[];
-
-	filter_with?: Id<any>[];
-
-	filter_without?: Id<any>[];
 } & Iter<T>;
 
 export class World {


### PR DESCRIPTION
## Brief Description of your Changes.

Updates the TS types to include the query.has method, as well as few other (perhaps useful) types like ids, filter_with, filter_without, and archetype_map. Although these are typed as Id<any> since thats what the Luau type is set to. Unsure if this shouldn't be done for TS

## Impact of your Changes

Only ts types

## Tests Performed

None required

## Additional Comments

TS Type update