### PR TITLE
Correct Cleanup example: Change OnSet to OnAdd

### DIFF
--- a/examples/hooks/cleanup.luau
+++ b/examples/hooks/cleanup.luau
@@ -15,6 +15,7 @@ end)
 
 world:set(Model, jecs.OnAdd, function(entity, id, model)
 	-- OnAdd is invoked after the data has been assigned.
+	-- This hook only fires the first time the component is added.
 	-- It also returns the data for faster access.
 	-- There may be some logic to do some side effects on reassignments
 	model:SetAttribute("entityId", entity)


### PR DESCRIPTION
## Brief Description of your Changes.

`jecs.OnSet` no longer exists. This should be `jecs.OnAdd` instead, which does exist.

## Impact of your Changes

No impact beyond updating an example file.