### PR TITLE
Implement world:targets() as a valid method

### DIFF
--- a/src/jecs.luau
+++ b/src/jecs.luau
@@ -3348,7 +3348,7 @@ local function world_new(DEBUG: boolean?)
 			if nth == end_count then
 				return nil
 			end
-			local target = dense_array[sparse_array[ECS_ID(ECS_PAIR_SECOND(archetype_types[nth]))].dense]
+			local target = dense_array[sparse_array[ECS_PAIR_SECOND(archetype_types[nth])].dense]
 			nth += 1
 			return target
 		end

--- a/src/jecs.luau
+++ b/src/jecs.luau
@@ -3341,7 +3341,7 @@ local function world_new(DEBUG: boolean?)
 				return nil
 			end
 			local target = entity_index_get_alive(world.entity_index,
-		    	ECS_PAIR_SECOND(nth))
+		    	ECS_PAIR_SECOND(archetype.types[nth + idr.records[archetype_id]]))
 			nth += 1
 			return target
 		end

--- a/src/jecs.luau
+++ b/src/jecs.luau
@@ -194,6 +194,7 @@ type world = {
 	entity: (self: world, id: i53?) -> i53,
 	component: (self: world) -> i53,
 	target: (self: world, id: i53, relation: i53, index: number?) -> i53?,
+	targets: (self: world, id: i53, relation: i53) -> () -> i53?,
 	delete: (self: world, id: i53) -> (),
 	add: (self: world, id: i53, component: i53) -> (),
 	set: (self: world, id: i53, component: i53, data: any) -> (),
@@ -252,6 +253,13 @@ export type World = {
 		relation: ecs_entity_t<Component>,
 		index: number?
 	) -> Entity<unknown>?,
+
+	-- Gets an iterator for all viable targets of a relationship
+	targets: <T>(
+		self: World,
+		id: Entity<T> | number,
+		relation: ecs_entity_t<Component>
+	) -> () -> Id,
 
 	--- Deletes an entity and all it's related components and relationships.
 	delete: <T>(self: World, id: Entity<T>) -> (),
@@ -3302,6 +3310,43 @@ local function world_new(DEBUG: boolean?)
 		    ECS_PAIR_SECOND(nth))
 	end
 
+	local function world_targets(world: world, entity: i53, relation: i53): () -> i53?
+		local record = entity_index_try_get_unsafe(entity)
+		if not record then
+			return NOOP :: () -> i53
+		end
+
+		local archetype = record.archetype
+		if not archetype then
+			return NOOP :: () -> i53
+		end
+
+		local r = ECS_PAIR(relation, EcsWildcard)
+		local idr = world.component_index[r]
+
+		if not idr then
+			return NOOP :: () -> i53
+		end
+
+		local archetype_id = archetype.id
+		local count = idr.counts[archetype_id]
+		if not count then
+			return NOOP :: () -> i53
+		end
+
+		local nth = 0
+
+		return function(): i53?
+			if nth == count then
+				return nil
+			end
+			local target = entity_index_get_alive(world.entity_index,
+		    	ECS_PAIR_SECOND(nth))
+			nth += 1
+			return target
+		end
+	end
+
 	local function world_parent(world: world, entity: i53): i53?
 		return world_target(world, entity, EcsChildOf, 0)
 	end
@@ -3730,6 +3775,7 @@ local function world_new(DEBUG: boolean?)
 	world.get = world_get :: any
 	world.has = world_has :: any
 	world.target = world_target
+	world.targets = world_targets
 	world.parent = world_parent
 	world.contains = world_contains
 	world.exists = world_exists

--- a/src/jecs.luau
+++ b/src/jecs.luau
@@ -3340,15 +3340,15 @@ local function world_new(DEBUG: boolean?)
 		local nth = idr.records[archetype_id]
 		local end_count = nth + count
 
-		local entity_idx = world.entity_index
 		local archetype_types = archetype.types
+		local sparse_array = entity_index.sparse_array
+		local dense_array = entity_index.dense_array
 
 		return function(): i53?
 			if nth == end_count then
 				return nil
 			end
-			local target = entity_index_get_alive(entity_idx,
-		    	ECS_PAIR_SECOND(archetype_types[nth]))
+			local target = dense_array[sparse_array[ECS_ID(ECS_PAIR_SECOND(archetype_types[nth]))].dense]
 			nth += 1
 			return target
 		end

--- a/src/jecs.luau
+++ b/src/jecs.luau
@@ -3334,6 +3334,7 @@ local function world_new(DEBUG: boolean?)
 			return NOOP :: () -> i53
 		end
 
+		local idr_record = idr.records[archetype_id]
 		local nth = 0
 
 		return function(): i53?
@@ -3341,7 +3342,7 @@ local function world_new(DEBUG: boolean?)
 				return nil
 			end
 			local target = entity_index_get_alive(world.entity_index,
-		    	ECS_PAIR_SECOND(archetype.types[nth + idr.records[archetype_id]]))
+		    	ECS_PAIR_SECOND(archetype.types[nth + idr_record]))
 			nth += 1
 			return target
 		end

--- a/src/jecs.luau
+++ b/src/jecs.luau
@@ -3334,15 +3334,18 @@ local function world_new(DEBUG: boolean?)
 			return NOOP :: () -> i53
 		end
 
-		local idr_record = idr.records[archetype_id]
-		local nth = 0
+		local nth = idr.records[archetype_id]
+		local end_count = nth + count
+
+		local entity_idx = world.entity_index
+		local archetype_types = archetype.types
 
 		return function(): i53?
-			if nth == count then
+			if nth == end_count then
 				return nil
 			end
-			local target = entity_index_get_alive(world.entity_index,
-		    	ECS_PAIR_SECOND(archetype.types[nth + idr_record]))
+			local target = entity_index_get_alive(entity_idx,
+		    	ECS_PAIR_SECOND(archetype_types[nth]))
 			nth += 1
 			return target
 		end

--- a/src/jecs.luau
+++ b/src/jecs.luau
@@ -3311,7 +3311,7 @@ local function world_new(DEBUG: boolean?)
 	end
 
 	local NOOP = NOOP :: () -> i53
-	
+
 	local function world_targets(world: world, entity: i53, relation: i53): () -> i53?
 		local record = entity_index_try_get_unsafe(entity)
 		if not record then
@@ -3324,7 +3324,8 @@ local function world_new(DEBUG: boolean?)
 		end
 
 		local r = ECS_PAIR(relation, EcsWildcard)
-		local idr = world.component_index[r]
+		local ct_idx = world.component_index
+		local idr = ct_idx[r]
 
 		if not idr then
 			return NOOP

--- a/src/jecs.luau
+++ b/src/jecs.luau
@@ -3310,9 +3310,9 @@ local function world_new(DEBUG: boolean?)
 		    ECS_PAIR_SECOND(nth))
 	end
 
+	local NOOP = NOOP :: () -> i53
+	
 	local function world_targets(world: world, entity: i53, relation: i53): () -> i53?
-		local NOOP = NOOP :: () -> i53
-
 		local record = entity_index_try_get_unsafe(entity)
 		if not record then
 			return NOOP

--- a/src/jecs.luau
+++ b/src/jecs.luau
@@ -3311,27 +3311,29 @@ local function world_new(DEBUG: boolean?)
 	end
 
 	local function world_targets(world: world, entity: i53, relation: i53): () -> i53?
+		local NOOP = NOOP :: () -> i53
+
 		local record = entity_index_try_get_unsafe(entity)
 		if not record then
-			return NOOP :: () -> i53
+			return NOOP
 		end
 
 		local archetype = record.archetype
 		if not archetype then
-			return NOOP :: () -> i53
+			return NOOP
 		end
 
 		local r = ECS_PAIR(relation, EcsWildcard)
 		local idr = world.component_index[r]
 
 		if not idr then
-			return NOOP :: () -> i53
+			return NOOP
 		end
 
 		local archetype_id = archetype.id
 		local count = idr.counts[archetype_id]
 		if not count then
-			return NOOP :: () -> i53
+			return NOOP
 		end
 
 		local nth = idr.records[archetype_id]

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -3365,10 +3365,7 @@ TEST("world:targets()", function()
 			end
 
 			for j = 1, #all_targets do
-				local t: Entity
-				while t == nil do
-					t = all_targets[j]
-				end
+				local t = all_targets[j]
 
 				if math.random() < 0.5 then
 					world:remove(e, jecs.pair(ROOT, t))

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -3364,7 +3364,12 @@ TEST("world:targets()", function()
 				CHECK(seen[t] == true)
 			end
 
-			for t in world:targets(e, ROOT) do
+			for j = 1, #all_targets do
+				local t: Entity
+				while t == nil do
+					t = all_targets[j]
+				end
+
 				if math.random() < 0.5 then
 					world:remove(e, jecs.pair(ROOT, t))
 					alive[t] = nil

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -3344,7 +3344,7 @@ TEST("world:targets()", function()
 			if dense > entity_index.alive_count then
 				return false
 			end
-			return true
+			return entity_index.dense_array[dense] ~= nil
 
 		end
 

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -3077,7 +3077,7 @@ TEST("world:set()", function()
 	end
 end)
 
-TEST("world:target", function()
+TEST("world:target()", function()
 	do CASE "nth index"
 		local world = jecs.world()
 		local A = world:component()
@@ -3178,7 +3178,7 @@ TEST("world:target", function()
 	end
 end)
 
-TEST("world:targets", function()
+TEST("world:targets()", function()
 	do CASE "can find single relation"
 		local world = jecs.world()
 

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -3077,6 +3077,130 @@ TEST("world:set()", function()
 	end
 end)
 
+TEST("world:targets", function()
+	do CASE "can find single relation"
+		local world = jecs.world()
+
+		local Alice = world:entity()
+		local Bob = world:entity()
+		local Likes = world:entity()
+
+		world:add(Alice, jecs.pair(Likes, Bob))
+
+		local i = 0
+		for target in world:targets(Alice, Likes) do
+			i += 1
+			CHECK(target == Bob)
+		end
+		CHECK(i == 1)
+	end
+	do CASE "basic iteration"
+		local world = jecs.world()
+
+		local ROOT = world:entity()
+		local e1 = world:entity()
+		local targets = {}
+
+		for i = 1, 10 do
+			local target = world:entity()
+			targets[i] = target
+			world:add(e1, pair(ROOT, target))
+		end
+
+		local i = 0
+		for target in world:targets(e1, ROOT) do
+			i += 1
+			CHECK(targets[i] == target)
+		end
+
+		CHECK(i == 10)
+	end
+	do CASE "multiple iterations"
+		local world = jecs.world()
+
+		local ROOT = world:entity()
+		local OTHER = world:entity()
+
+		local e = world:entity()
+
+		local root_targets = {}
+		local other_targets = {}
+
+		for i = 1, 5 do
+			local t = world:entity()
+			root_targets[i] = t
+			world:add(e, pair(ROOT, t))
+		end
+
+		for i = 1, 3 do
+			local t = world:entity()
+			other_targets[i] = t
+			world:add(e, pair(OTHER, t))
+		end
+
+		local i = 0
+		for target in world:targets(e, ROOT) do
+			i += 1
+			CHECK(root_targets[i] == target)
+		end
+		CHECK(i == 5)
+
+		local j = 0
+		for target in world:targets(e, OTHER) do
+			j += 1
+			CHECK(other_targets[j] == target)
+		end
+		CHECK(j == 3)
+	end
+	do CASE "empty iterator"
+		local world = jecs.world()
+
+		local ROOT = world:entity()
+		local OTHER = world:entity()
+
+		local e = world:entity()
+
+		world:add(e, pair(ROOT, world:entity()))
+
+		local count = 0
+		for _ in world:targets(e, OTHER) do
+			count += 1
+		end
+
+		CHECK(count == 0)
+	end
+	do CASE "ignore deleted targets"
+		local world = jecs.world()
+
+		local ROOT = world:entity()
+		local e = world:entity()
+
+		local alive = {}
+		local dead = {}
+
+		for i = 1, 3 do
+			local t = world:entity()
+			alive[#alive + 1] = t
+			world:add(e, pair(ROOT, t))
+		end
+
+		for i = 1, 2 do
+			local t = world:entity()
+			dead[#dead + 1] = t
+			world:add(e, pair(ROOT, t))
+			world:delete(t)
+		end
+
+		local count = 0
+		for t in world:targets(e, ROOT) do
+			count += 1
+			CHECK(t ~= nil)
+		end
+
+		CHECK(count == #alive)
+	end
+end)
+
 TEST("world:target", function()
 	do CASE "nth index"
 		local world = jecs.world()

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -3179,7 +3179,7 @@ TEST("world:target()", function()
 end)
 
 TEST("world:targets()", function()
-	do CASE "can find single relation"
+	do CASE "should find single relation"
 		local world = jecs.world()
 
 		local Alice = world:entity()
@@ -3270,7 +3270,7 @@ TEST("world:targets()", function()
 
 		CHECK(count == 0)
 	end
-	do CASE "ignore deleted targets"
+	do CASE "should ignore deleted targets"
 		local world = jecs.world()
 
 		local ROOT = world:entity()

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -3077,6 +3077,107 @@ TEST("world:set()", function()
 	end
 end)
 
+TEST("world:target", function()
+	do CASE "nth index"
+		local world = jecs.world()
+		local A = world:component()
+		world:set(A, jecs.Name, "A")
+		local B = world:component()
+		world:set(B, jecs.Name, "B")
+		local C = world:component()
+		world:set(C, jecs.Name, "C")
+		local D = world:component()
+		world:set(D, jecs.Name, "D")
+		local E = world:component()
+		world:set(E, jecs.Name, "E")
+		local e = world:entity()
+
+		world:add(e, pair(A, B))
+		world:add(e, pair(A, C))
+		world:add(e, pair(A, D))
+		world:add(e, pair(A, E))
+		world:add(e, pair(B, C))
+		world:add(e, pair(B, D))
+		world:add(e, pair(C, D))
+
+		CHECK((pair(A, B) :: any) < (pair(A, C) :: any))
+		CHECK((pair(A, C) :: any) < (pair(A, D) :: any))
+		CHECK((pair(C, A) :: any) < (pair(C, D) :: any))
+
+		CHECK(jecs.pair_first(world, pair(B, C)) == B)
+		local r = (jecs.entity_index_try_get(world.entity_index :: any, e :: any) :: any) :: jecs.Record
+		local archetype = r.archetype
+		local function cdr(id)
+			return assert(jecs.component_record(world, id))
+		end
+		local idr_b_c = cdr(pair(B, C))
+		local idr_a_wc = cdr(pair(A, __))
+		local idr_a_e = cdr(pair(A, E))
+
+		CHECK(idr_a_wc.counts[archetype.id] == 4)
+		CHECK(idr_b_c.records[archetype.id] > idr_a_e.records[archetype.id])
+		CHECK(world:target(e, A, 0) == B)
+		CHECK(world:target(e, A, 1) == C)
+		CHECK(world:target(e, A, 2) == D)
+		CHECK(world:target(e, A, 3) == E)
+		CHECK(world:target(e, B, 0) == C)
+		CHECK(world:target(e, B, 1) == D)
+		CHECK(world:target(e, C, 0) == D)
+		CHECK(world:target(e, C, 1) == nil)
+
+		CHECK(cdr(pair(A, B)).records[archetype.id] == 1)
+		CHECK(cdr(pair(A, C)).records[archetype.id] == 2)
+		CHECK(cdr(pair(A, D)).records[archetype.id] == 3)
+		CHECK(cdr(pair(A, E)).records[archetype.id] == 4)
+
+		CHECK(world:target(e, C, 0) == D)
+		CHECK(world:target(e, C, 1) == nil)
+	end
+
+	do CASE "infer index when unspecified"
+		local world = jecs.world()
+		local A = world:component()
+		local B = world:component()
+		local C = world:component()
+		local D = world:component()
+		local e = world:entity()
+
+		world:add(e, pair(A, B))
+		world:add(e, pair(A, C))
+		world:add(e, pair(B, C))
+		world:add(e, pair(B, D))
+		world:add(e, pair(C, D))
+
+		CHECK(world:target(e, A) == world:target(e, A, 0))
+		CHECK(world:target(e, B) == world:target(e, B, 0))
+		CHECK(world:target(e, C) == world:target(e, C, 0))
+	end
+
+	do CASE "loop until no target"
+		local world = jecs.world()
+
+		local ROOT = world:entity()
+		local e1 = world:entity()
+		local targets = {}
+
+		for i = 1, 10 do
+			local target = world:entity()
+			targets[i] = target
+			world:add(e1, pair(ROOT, target))
+		end
+
+		local i = 0
+		local target = world:target(e1, ROOT, 0)
+		while target do
+			i += 1
+			CHECK(targets[i] == target)
+			target = world:target(e1, ROOT, i)
+		end
+
+		CHECK(i == 10)
+	end
+end)
+
 TEST("world:targets", function()
 	do CASE "can find single relation"
 		local world = jecs.world()
@@ -3198,107 +3299,6 @@ TEST("world:targets", function()
 		end
 
 		CHECK(count == #alive)
-	end
-end)
-
-TEST("world:target", function()
-	do CASE "nth index"
-		local world = jecs.world()
-		local A = world:component()
-		world:set(A, jecs.Name, "A")
-		local B = world:component()
-		world:set(B, jecs.Name, "B")
-		local C = world:component()
-		world:set(C, jecs.Name, "C")
-		local D = world:component()
-		world:set(D, jecs.Name, "D")
-		local E = world:component()
-		world:set(E, jecs.Name, "E")
-		local e = world:entity()
-
-		world:add(e, pair(A, B))
-		world:add(e, pair(A, C))
-		world:add(e, pair(A, D))
-		world:add(e, pair(A, E))
-		world:add(e, pair(B, C))
-		world:add(e, pair(B, D))
-		world:add(e, pair(C, D))
-
-		CHECK((pair(A, B) :: any) < (pair(A, C) :: any))
-		CHECK((pair(A, C) :: any) < (pair(A, D) :: any))
-		CHECK((pair(C, A) :: any) < (pair(C, D) :: any))
-
-		CHECK(jecs.pair_first(world, pair(B, C)) == B)
-		local r = (jecs.entity_index_try_get(world.entity_index :: any, e :: any) :: any) :: jecs.Record
-		local archetype = r.archetype
-		local function cdr(id)
-			return assert(jecs.component_record(world, id))
-		end
-		local idr_b_c = cdr(pair(B, C))
-		local idr_a_wc = cdr(pair(A, __))
-		local idr_a_e = cdr(pair(A, E))
-
-		CHECK(idr_a_wc.counts[archetype.id] == 4)
-		CHECK(idr_b_c.records[archetype.id] > idr_a_e.records[archetype.id])
-		CHECK(world:target(e, A, 0) == B)
-		CHECK(world:target(e, A, 1) == C)
-		CHECK(world:target(e, A, 2) == D)
-		CHECK(world:target(e, A, 3) == E)
-		CHECK(world:target(e, B, 0) == C)
-		CHECK(world:target(e, B, 1) == D)
-		CHECK(world:target(e, C, 0) == D)
-		CHECK(world:target(e, C, 1) == nil)
-
-		CHECK(cdr(pair(A, B)).records[archetype.id] == 1)
-		CHECK(cdr(pair(A, C)).records[archetype.id] == 2)
-		CHECK(cdr(pair(A, D)).records[archetype.id] == 3)
-		CHECK(cdr(pair(A, E)).records[archetype.id] == 4)
-
-		CHECK(world:target(e, C, 0) == D)
-		CHECK(world:target(e, C, 1) == nil)
-	end
-
-	do CASE "infer index when unspecified"
-		local world = jecs.world()
-		local A = world:component()
-		local B = world:component()
-		local C = world:component()
-		local D = world:component()
-		local e = world:entity()
-
-		world:add(e, pair(A, B))
-		world:add(e, pair(A, C))
-		world:add(e, pair(B, C))
-		world:add(e, pair(B, D))
-		world:add(e, pair(C, D))
-
-		CHECK(world:target(e, A) == world:target(e, A, 0))
-		CHECK(world:target(e, B) == world:target(e, B, 0))
-		CHECK(world:target(e, C) == world:target(e, C, 0))
-	end
-
-	do CASE "loop until no target"
-		local world = jecs.world()
-
-		local ROOT = world:entity()
-		local e1 = world:entity()
-		local targets = {}
-
-		for i = 1, 10 do
-			local target = world:entity()
-			targets[i] = target
-			world:add(e1, pair(ROOT, target))
-		end
-
-		local i = 0
-		local target = world:target(e1, ROOT, 0)
-		while target do
-			i += 1
-			CHECK(targets[i] == target)
-			target = world:target(e1, ROOT, i)
-		end
-
-		CHECK(i == 10)
 	end
 end)
 

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -3300,6 +3300,81 @@ TEST("world:targets()", function()
 
 		CHECK(count == #alive)
 	end
+	do CASE "should properly handle rapid add/remove calls"
+		local world = jecs.world()
+
+		local ROOT = world:entity()
+		local e = world:entity()
+
+		local alive = {}
+		local all_targets = {} :: {Entity}
+
+		for i = 1, 100 do
+			local t = world:entity()
+			all_targets[#all_targets + 1] = t
+
+			world:add(e, jecs.pair(ROOT, t))
+			alive[t] = true
+		end
+
+		for i = 1, 500 do
+			local t: Entity
+			while t == nil do
+				t = all_targets[math.random(#all_targets)]
+			end
+
+			if math.random() < 0.5 then
+				world:remove(e, jecs.pair(ROOT, t))
+				alive[t] = nil
+			else
+				world:add(e, jecs.pair(ROOT, t))
+				alive[t] = true
+			end
+		end
+
+		local entity_index = world.entity_index
+		local function entity_index_check_alive(entity)
+			local r = entity_index.sparse_array[ECS_ID(entity)]
+
+			if not r or r.dense == 0 then
+				return false
+			end
+
+			local dense = r.dense
+			if dense > entity_index.alive_count then
+				return false
+			end
+			return true
+
+		end
+
+		for i=1, 10 do
+			local seen = {}
+			for t in world:targets(e, ROOT) do
+				CHECK(entity_index_check_alive(t))
+				CHECK(entity_index_check_alive(jecs.pair(ROOT, t)))
+
+				CHECK(alive[t] == true)
+
+				CHECK(seen[t] == nil)
+				seen[t] = true
+			end
+
+			for t, _ in pairs(alive) do
+				CHECK(seen[t] == true)
+			end
+
+			for t in world:targets(e, ROOT) do
+				if math.random() < 0.5 then
+					world:remove(e, jecs.pair(ROOT, t))
+					alive[t] = nil
+				else
+					world:add(e, jecs.pair(ROOT, t))
+					alive[t] = true
+				end
+			end
+		end
+	end
 end)
 
 TEST("#adding a recycled target", function()


### PR DESCRIPTION
## Brief Description of your Changes.

Closes #309. 
This PR introduces the `world:targets()` syntax described in that issue.

An an example, assuming the following scenario:

```luau
local world = jecs.world()

local Alice = world:entity()
local Bob = world:entity()

local Likes = world:entity()

world:set(Alice, jecs.Name, "Alice")
world:set(Bob, jecs.Name, "Bob")

world:add(Alice, jecs.pair(Likes, Bob))
```

The question of "Who does Alice like?" could be many people.

The following is valid syntax under this PR:

```luau
for target in world:targets(Alice, Likes) do
	print(world:get(target, jecs.Name)) -- Bob
end
```

The motivation for this change is to reduce the boilerplate for doing the equivalent action with current methods (and hopefully make it a little faster):

```luau
local nth = 0
while true do
	local target = world:target(Alice, Likes, nth)
	if not target then
		break
	end
	print(world:get(target, jecs.Name)) -- Bob
end
```
---

A real world example of where this can be applied is timers. [See this discord message for where I got this.](https://discord.com/channels/385151591524597761/1248734074940559511/1395703677561475193)

```luau
for e in world:query(pair(Timer, jecs.Wildcard)) do
	local nth = 0
	while true do 
		local t = world:target(e, Timer, nth)
		if not t then 
			break
		end
		local timer = world:get(e, pair(Timer, t))
		timer.time_left -= dt
		nth += 1
	end
end
```

This can be converted to:

```luau
for e in world:query(pair(Timer, jecs.Wildcard)) do
	for t in world:targets(e, Timer) do
		local timer = world:get(e, pair(Timer, t))
		timer.time_left -= dt
	end
end
```

## Impact of your Changes

Initially this PR was meant to reduce the boilerplate required to do this type of operation. On further investigation after implementing unit tests, performance for the new syntax, upon initial benchmarks, shows promising improvements to performance in most cases. The code for this benchmark can be found [here](https://gist.github.com/kurokuukyo/138a4e7953dd78b1edf966d8523da37e).

Since the start of this PR the benchmark has changed in a good way. We were at 115 μs as a 50% and have dropped down to 100μs!

<img width="1278" height="506" alt="Screenshot 2026-04-20 211729" src="https://github.com/user-attachments/assets/75884d9e-e772-491f-8a75-aa093c537f70" />


<details>
<summary>Old Benchmark</summary>
<img width="1281" height="547" alt="Screenshot 2026-04-20 183548" src="https://github.com/user-attachments/assets/0b191292-b775-4437-bf9e-a4dbb105a2e6" />
</details>

## Tests Performed

Unit tests have been added and are passing as of submission of the PR [(see changes to tests.luau)](https://github.com/Ukendio/jecs/pull/311/changes#diff-aedaaadae297b9caf24c4deba1f7b0625a7402a0a4d4ee8d0643784c97fb39e7R3181). Previously mentioned in the motivation section, the benchmarks also show this can be more performant than the current method. Additional unit tests can be added as requested and necessary.

## Additional Comments

See: [alternative syntax proposal](https://github.com/Ukendio/jecs/issues/309#issuecomment-4012036050)
A comment in the initial issue suggested the following syntax be valid (introduce nth in the iterator):

```luau
for target, nth in world:targets(Alice, Likes) do
	print(world:get(target, jecs.Name)) -- Bob
end
```

I do not see a reason why this should be included. It is fairly trivial to include if code review later on reveals a reason to include it.

