### PR TITLE
perf: hot-path optimizations across entity ops, relationships, and lifecycle (18 workloads +4-35% faster, 0 regressions)

### DIFF
--- a/src/jecs.luau
+++ b/src/jecs.luau
@@ -179,6 +179,11 @@ type record = {
 	archetype: archetype,
 	row: number,
 	dense: i24,
+	-- The canonical (generation-carrying) id this record currently belongs
+	-- to, maintained alongside dense_array so hot paths can validate a
+	-- handle with a single field compare instead of the dense_array load.
+	-- nil on records that were pre-populated but never made alive.
+	entity: i53?,
 }
 type entityindex = {
 	dense_array: Map<number, i53>,
@@ -619,7 +624,7 @@ local function ENTITY_INDEX_NEW_ID(world: world): i53
 	entity_index.max_id = id
 	entity_index.alive_count = next_count
 	dense_array[next_count] = id
-	sparse_array[id] = { dense = next_count, row = 0, archetype = ROOT_ARCHETYPE }
+	sparse_array[id] = { dense = next_count, row = 0, archetype = ROOT_ARCHETYPE, entity = id }
 
 	return id
 end
@@ -2923,7 +2928,7 @@ local function world_new(DEBUG: boolean?)
 
 	local function world_set(world: world, entity: i53, id: i53, data): ()
 		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
-		if not record or eindex_dense_array[record.dense] ~= entity then
+		if not record or record.entity ~= entity then
 			return
 		end
 
@@ -3030,7 +3035,7 @@ local function world_new(DEBUG: boolean?)
 		id: i53
 	): ()
 		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
-		if not record or eindex_dense_array[record.dense] ~= entity then
+		if not record or record.entity ~= entity then
 			return
 		end
 
@@ -3128,7 +3133,7 @@ local function world_new(DEBUG: boolean?)
 	local function world_get(world: world, entity: i53,
 		a: i53, b: i53?, c: i53?, d: i53?, e: i53?): ...any
 		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
-		if not record or eindex_dense_array[record.dense] ~= entity then
+		if not record or record.entity ~= entity then
 			return nil
 		end
 
@@ -3300,7 +3305,7 @@ local function world_new(DEBUG: boolean?)
 		a: i53, b: i53?, c: i53?, d: i53?, e: i53?): boolean
 
 		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
-		if not record or eindex_dense_array[record.dense] ~= entity then
+		if not record or record.entity ~= entity then
 			return false
 		end
 
@@ -3325,7 +3330,7 @@ local function world_new(DEBUG: boolean?)
 
 	local function world_target(world: world, entity: i53, relation: i53, index: number?): i53?
 		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
-		if not record or eindex_dense_array[record.dense] ~= entity then
+		if not record or record.entity ~= entity then
 			return nil
 		end
 
@@ -3378,7 +3383,7 @@ local function world_new(DEBUG: boolean?)
 
 	local function world_targets(world: world, entity: i53, relation: i53): () -> i53?
 		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
-		if not record or eindex_dense_array[record.dense] ~= entity then
+		if not record or record.entity ~= entity then
 			return NOOP
 		end
 
@@ -3425,7 +3430,7 @@ local function world_new(DEBUG: boolean?)
 	-- known, index is always 0, and parent lookups are a per-frame staple.
 	local function world_parent(world: world, entity: i53): i53?
 		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
-		if not record or eindex_dense_array[record.dense] ~= entity then
+		if not record or record.entity ~= entity then
 			return nil
 		end
 
@@ -3523,6 +3528,7 @@ local function world_new(DEBUG: boolean?)
 					alive_count += 1
 					entity_index.alive_count = alive_count
 					r.dense = alive_count
+					r.entity = entity
 					dense_array[alive_count] = entity
 					return entity
 				end
@@ -3533,6 +3539,7 @@ local function world_new(DEBUG: boolean?)
 					alive_count += 1
 					entity_index.alive_count = alive_count
 					r.dense = alive_count
+					r.entity = entity
 					dense_array[alive_count] = entity
 					return entity
 				end
@@ -3552,7 +3559,7 @@ local function world_new(DEBUG: boolean?)
 				entity_index.alive_count = alive_count
 				dense_array[alive_count] = entity
 
-				r = { dense = alive_count, row = 0, archetype = ROOT_ARCHETYPE }
+				r = { dense = alive_count, row = 0, archetype = ROOT_ARCHETYPE, entity = entity } :: record
 				sparse_array[index] = r
 
 				return entity
@@ -3577,13 +3584,13 @@ local function world_new(DEBUG: boolean?)
 		entity_index.max_id = id
 		entity_index.alive_count = next_count
 		dense_array[next_count] = id
-		sparse_array[id] = { dense = next_count, row = 0, archetype = ROOT_ARCHETYPE }
+		sparse_array[id] = { dense = next_count, row = 0, archetype = ROOT_ARCHETYPE, entity = id }
 		return id
 	end
 
 	local function world_remove(world: world, entity: i53, id: i53)
 		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
-		if not record or eindex_dense_array[record.dense] ~= entity then
+		if not record or record.entity ~= entity then
 			return
 		end
 		local from = record.archetype
@@ -3612,7 +3619,7 @@ local function world_new(DEBUG: boolean?)
 
 	local function world_delete(world: world, entity: i53)
 		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
-		if not record or eindex_dense_array[record.dense] ~= entity then
+		if not record or record.entity ~= entity then
 			return
 		end
 
@@ -3917,14 +3924,16 @@ local function world_new(DEBUG: boolean?)
 		-- to 0 at ECS_GENERATION_MASK. (The unified formula is exactly
 		-- equivalent to the original's two branches for every input.)
 		local next_gen = entity // ECS_ENTITY_MASK + 1
-		eindex_dense_array[i_swap] = if next_gen >= ECS_GENERATION_MASK
+		local bumped = if next_gen >= ECS_GENERATION_MASK
 			then entity_lo
 			else entity_lo + next_gen * ECS_ENTITY_MASK
+		eindex_dense_array[i_swap] = bumped
+		record.entity = bumped
 	end
 
 	local function world_clear(world: world, entity: i53)
 		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
-		if not record or eindex_dense_array[record.dense] ~= entity then
+		if not record or record.entity ~= entity then
 			return
 		end
 
@@ -3987,17 +3996,14 @@ local function world_new(DEBUG: boolean?)
 
 	local function world_contains(world: world, entity: i53): boolean
 		-- Inlined entity_index_is_alive -> entity_index_try_get: alive means
-		-- the sparse record exists, is allocated (dense ~= 0), sits within
-		-- the alive range, and the dense slot holds this exact generation.
+		-- the record currently belongs to this exact generation AND sits
+		-- within the alive range (record.entity matching implies dense ~= 0,
+		-- since only alive-making paths assign it).
 		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
-		if not record then
+		if not record or record.entity ~= entity then
 			return false
 		end
-		local dense = record.dense
-		if dense == 0 or dense > entity_index.alive_count then
-			return false
-		end
-		return eindex_dense_array[dense] == entity
+		return record.dense <= entity_index.alive_count
 	end
 
 	local function world_cleanup(world: world)
@@ -4225,6 +4231,7 @@ local function entity_index_ensure(entity_index: entityindex, e: i53)
 			alive_count += 1
 			entity_index.alive_count = alive_count
 			r.dense = alive_count
+			r.entity = e
 			eindex_dense_array[alive_count] = e
 			return e
 		end
@@ -4235,6 +4242,7 @@ local function entity_index_ensure(entity_index: entityindex, e: i53)
 			alive_count += 1
 			entity_index.alive_count = alive_count
 			r.dense = alive_count
+			r.entity = e
 			eindex_dense_array[alive_count] = e
 			return e
 		end
@@ -4260,7 +4268,7 @@ local function entity_index_ensure(entity_index: entityindex, e: i53)
 		entity_index.alive_count = alive_count
 		eindex_dense_array[alive_count] = e
 
-		r = { dense = alive_count } :: record
+		r = { dense = alive_count, entity = e } :: record
 		eindex_sparse_array[index] = r
 
 		return e

--- a/src/jecs.luau
+++ b/src/jecs.luau
@@ -596,7 +596,9 @@ local function ENTITY_INDEX_NEW_ID(world: world): i53
 
 	local id = max_id + 1
 	local range_end = entity_index.range_end
-	ecs_assert(range_end == nil or id < range_end, ECS_INTERNAL_ERROR_INCOMPATIBLE_ENTITY)
+	if range_end ~= nil and id >= range_end then
+		error(ECS_INTERNAL_ERROR_INCOMPATIBLE_ENTITY)
+	end
 
 	entity_index.max_id = id
 	entity_index.alive_count = next_count
@@ -2774,17 +2776,22 @@ local function world_new(DEBUG: boolean?)
 		return r
 	end
 
-	local function inner_archetype_move(
+	-- Fused append + column move + record update. This is the per-entity hot
+	-- path for every archetype transition (set/add/remove), so the previous
+	-- new_entity/archetype_append/inner_archetype_move call chain is inlined
+	-- into a single function, and the duplicated dst_entities store is gone.
+	local function inner_entity_move(
 		entity: i53,
-		to: archetype,
-		dst_row: i24,
-		from: archetype,
-		src_row: i24
+		record: record,
+		to: archetype
 	)
-		local src_columns = from.columns
-		local dst_entities = to.entities
+		local src_row = record.row
+		local from = record.archetype
 		local src_entities = from.entities
+		local dst_entities = to.entities
+		local dst_row = #dst_entities + 1
 
+		local src_columns = from.columns
 		local last = #src_entities
 		local id_types = from.types
 		local columns_map = to.columns_map
@@ -2807,7 +2814,7 @@ local function world_new(DEBUG: boolean?)
 			local e2 = src_entities[last]
 			src_entities[src_row] = e2
 
-			local record2 = eindex_sparse_array[ECS_ENTITY_T_LO(e2)]
+			local record2 = eindex_sparse_array[e2 % ECS_ENTITY_MASK]
 			record2.row = src_row
 		else
 			for i, column in src_columns do
@@ -2828,17 +2835,6 @@ local function world_new(DEBUG: boolean?)
 		end
 		src_entities[last] = nil :: any
 		dst_entities[dst_row] = entity
-	end
-
-	local function inner_entity_move(
-		entity: i53,
-		record: record,
-		to: archetype
-	)
-		local sourceRow = record.row
-		local from = record.archetype
-		local dst_row = archetype_append(entity, to)
-		inner_archetype_move(entity, to, dst_row, from, sourceRow)
 		record.archetype = to
 		record.row = dst_row
 	end
@@ -2890,29 +2886,29 @@ local function world_new(DEBUG: boolean?)
 	end
 
 	local function world_set(world: world, entity: i53, id: i53, data): ()
-		local record = entity_index_try_get_unsafe(entity)
-		if not record then
+		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
+		if not record or eindex_dense_array[record.dense] ~= entity then
 			return
 		end
 
 		local src = record.archetype
 		local column = src.columns_map[id]
 		if column then
-			local idr = component_index[id]
 			column[record.row] = data
 
 			-- If the archetypes are the same it can avoid moving the entity
 			-- and just set the data directly.
-			local on_change = idr.on_change
+			local on_change = component_index[id].on_change
 			if on_change then
 				on_change(entity, id, data, src)
 			end
 		else
 			local to: archetype
 			local idr: componentrecord
-			if ECS_IS_PAIR(id) then
-				local first = ECS_PAIR_FIRST(id)
-				local wc = ECS_PAIR(first, EcsWildcard)
+			if id > ECS_PAIR_OFFSET then
+				-- Inlined ECS_PAIR(ECS_PAIR_FIRST(id), EcsWildcard): strip the
+				-- low 24 object bits from the pair id and substitute Wildcard.
+				local wc = id - ((id - ECS_PAIR_OFFSET) % ECS_ENTITY_MASK) + EcsWildcard
 				idr = component_index[wc]
 
 				local edge = archetype_edges[src.id]
@@ -2970,17 +2966,20 @@ local function world_new(DEBUG: boolean?)
 				idr = component_index[id]
 			end
 
-			local ROOT_ARCHETYPE = ROOT_ARCHETYPE
-			local src_is_root_archetype = src == ROOT_ARCHETYPE
-			if not src_is_root_archetype then
+			if src ~= ROOT_ARCHETYPE then
 				-- If there was a previous archetype, then the entity needs to move the archetype
 				inner_entity_move(entity, record, to)
 			else
-				new_entity(entity, record, to)
+				-- Inlined new_entity/archetype_append: fresh entities come from
+				-- the root archetype, which never has columns to move.
+				local dst_entities = to.entities
+				local dst_row = #dst_entities + 1
+				dst_entities[dst_row] = entity
+				record.archetype = to
+				record.row = dst_row
 			end
 
-			column = to.columns_map[id]
-			column[record.row] = data
+			to.columns_map[id][record.row] = data
 
 			local on_add = idr.on_add
 			if on_add then
@@ -2994,8 +2993,8 @@ local function world_new(DEBUG: boolean?)
 		entity: i53,
 		id: i53
 	): ()
-		local record = entity_index_try_get_unsafe(entity :: number)
-		if not record then
+		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
+		if not record or eindex_dense_array[record.dense] ~= entity then
 			return
 		end
 
@@ -3006,9 +3005,10 @@ local function world_new(DEBUG: boolean?)
 		local to: archetype
 		local idr: componentrecord
 
-		if ECS_IS_PAIR(id) then
-			local first = ECS_PAIR_FIRST(id)
-			local wc = ECS_PAIR(first, EcsWildcard)
+		if id > ECS_PAIR_OFFSET then
+			-- Inlined ECS_PAIR(ECS_PAIR_FIRST(id), EcsWildcard): strip the
+			-- low 24 object bits from the pair id and substitute Wildcard.
+			local wc = id - ((id - ECS_PAIR_OFFSET) % ECS_ENTITY_MASK) + EcsWildcard
 			idr = component_index[wc]
 
 			local edge = archetype_edges[src.id]
@@ -3069,14 +3069,17 @@ local function world_new(DEBUG: boolean?)
 			idr = component_index[id]
 		end
 
-		local ROOT_ARCHETYPE = ROOT_ARCHETYPE
-		local src_is_root_archetype = src == ROOT_ARCHETYPE
-		if not src_is_root_archetype then
+		if src ~= ROOT_ARCHETYPE then
 			inner_entity_move(entity, record, to)
-		else
-			if #to.types > 0 then
-				new_entity(entity, record, to)
-			end
+		elseif to ~= ROOT_ARCHETYPE then
+			-- Inlined new_entity/archetype_append; `to ~= ROOT_ARCHETYPE` is
+			-- equivalent to the old `#to.types > 0` check (the root archetype
+			-- is the only one with an empty type) without the length op.
+			local dst_entities = to.entities
+			local dst_row = #dst_entities + 1
+			dst_entities[dst_row] = entity
+			record.archetype = to
+			record.row = dst_row
 		end
 
 		local on_add = idr.on_add
@@ -3088,29 +3091,37 @@ local function world_new(DEBUG: boolean?)
 
 	local function world_get(world: world, entity: i53,
 		a: i53, b: i53?, c: i53?, d: i53?, e: i53?): ...any
-		local record = entity_index_try_get_unsafe(entity)
-		if not record then
+		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
+		if not record or eindex_dense_array[record.dense] ~= entity then
 			return nil
 		end
 
-		local archetype = record.archetype
-
-		local columns_map = archetype.columns_map
+		local columns_map = record.archetype.columns_map
 		local row = record.row
 
-		local va = fetch(a, columns_map, row)
-
+		-- fetch() inlined per component; branch on the column table, never on
+		-- the value (stored values may legitimately be `false`).
+		local ca = columns_map[a]
+		local va = if ca then ca[row] else nil
 		if not b then
 			return va
-		elseif not c then
-			return va, fetch(b, columns_map, row)
-		elseif not d then
-			return va, fetch(b, columns_map, row), fetch(c, columns_map, row)
-		elseif not e then
-			return va, fetch(b, columns_map, row), fetch(c, columns_map, row), fetch(d, columns_map, row)
-		else
-			error("args exceeded")
 		end
+		local cb = columns_map[b]
+		local vb = if cb then cb[row] else nil
+		if not c then
+			return va, vb
+		end
+		local cc = columns_map[c]
+		local vc = if cc then cc[row] else nil
+		if not d then
+			return va, vb, vc
+		end
+		local cd = columns_map[d]
+		local vd = if cd then cd[row] else nil
+		if not e then
+			return va, vb, vc, vd
+		end
+		error("args exceeded")
 	end
 
 	type Listener<T> =
@@ -3252,8 +3263,8 @@ local function world_new(DEBUG: boolean?)
 	local function world_has(world: World, entity: i53,
 		a: i53, b: i53?, c: i53?, d: i53?, e: i53?): boolean
 
-		local record = entity_index_try_get_unsafe(entity)
-		if not record then
+		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
+		if not record or eindex_dense_array[record.dense] ~= entity then
 			return false
 		end
 
@@ -3264,8 +3275,13 @@ local function world_new(DEBUG: boolean?)
 
 		local columns_map = archetype.columns_map
 
+		-- Fast path: the overwhelmingly common single-id check.
+		if b == nil then
+			return columns_map[a] ~= nil
+		end
+
 		return columns_map[a] ~= nil and
-			(b == nil or columns_map[b] ~= nil) and
+			columns_map[b] ~= nil and
 			(c == nil or columns_map[c] ~= nil) and
 			(d == nil or columns_map[d] ~= nil) and
 			(e == nil or error("args exceeded"))
@@ -3424,7 +3440,9 @@ local function world_new(DEBUG: boolean?)
 		end
 		local id = max_id + 1
 		local range_end = entity_index.range_end
-		ecs_assert(range_end == nil or id < range_end, ECS_INTERNAL_ERROR_INCOMPATIBLE_ENTITY)
+		if range_end ~= nil and id >= range_end then
+			error(ECS_INTERNAL_ERROR_INCOMPATIBLE_ENTITY)
+		end
 		entity_index.max_id = id
 		entity_index.alive_count = next_count
 		dense_array[next_count] = id
@@ -3433,21 +3451,29 @@ local function world_new(DEBUG: boolean?)
 	end
 
 	local function world_remove(world: world, entity: i53, id: i53)
-		local record = entity_index_try_get_unsafe(entity)
-		if not record then
+		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
+		if not record or eindex_dense_array[record.dense] ~= entity then
 			return
 		end
 		local from = record.archetype
 
 		if from.columns_map[id] then
-			local idr = world.component_index[id]
-			local on_remove = idr.on_remove
+			local on_remove = component_index[id].on_remove
 
 			if on_remove then
 				on_remove(entity, id)
+				-- The hook may have moved the entity; refresh the source.
+				from = record.archetype
 			end
 
-			local to = archetype_traverse_remove(world, id, record.archetype)
+			-- Inlined archetype_traverse_remove using the captured upvalues.
+			local edge = archetype_edges[from.id]
+			local to = edge[id]
+			if to == nil then
+				to = find_archetype_without(world, from, id)
+				edge[id] = to
+				archetype_edges[to.id][id] = from
+			end
 
 			inner_entity_move(entity, record, to)
 		end

--- a/src/jecs.luau
+++ b/src/jecs.luau
@@ -3426,8 +3426,8 @@ local function world_new(DEBUG: boolean?)
 	local NOOP = NOOP :: () -> i53
 
 	local function world_targets(world: world, entity: i53, relation: i53): () -> i53?
-		local record = entity_index_try_get_unsafe(entity)
-		if not record then
+		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
+		if not record or eindex_dense_array[record.dense] ~= entity then
 			return NOOP
 		end
 
@@ -3436,9 +3436,9 @@ local function world_new(DEBUG: boolean?)
 			return NOOP
 		end
 
-		local r = ECS_PAIR(relation, EcsWildcard)
-		local ct_idx = world.component_index
-		local idr = ct_idx[r]
+		-- Inlined ECS_PAIR(relation, EcsWildcard).
+		local r = EcsWildcard + (relation % ECS_ENTITY_MASK) * ECS_ENTITY_MASK + ECS_PAIR_OFFSET
+		local idr = component_index[r]
 
 		if not idr then
 			return NOOP
@@ -3454,14 +3454,14 @@ local function world_new(DEBUG: boolean?)
 		local end_count = nth + count
 
 		local archetype_types = archetype.types
-		local sparse_array = entity_index.sparse_array
-		local dense_array = entity_index.dense_array
 
 		return function(): i53?
 			if nth == end_count then
 				return nil
 			end
-			local target = dense_array[sparse_array[ECS_PAIR_SECOND(archetype_types[nth])].dense]
+			-- Inlined ECS_PAIR_SECOND(archetype_types[nth]).
+			local target = eindex_dense_array[
+				eindex_sparse_array[(archetype_types[nth] - ECS_PAIR_OFFSET) % ECS_ENTITY_MASK].dense]
 			nth += 1
 			return target
 		end
@@ -3616,8 +3616,8 @@ local function world_new(DEBUG: boolean?)
 	end
 
 	local function world_delete(world: world, entity: i53)
-		local record = entity_index_try_get_unsafe(entity)
-		if not record then
+		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
+		if not record or eindex_dense_array[record.dense] ~= entity then
 			return
 		end
 
@@ -3633,13 +3633,50 @@ local function world_new(DEBUG: boolean?)
 					on_remove(entity, id, true)
 				end
 			end
-			archetype_delete(world, record.archetype, record.row)
+
+			-- Inlined archetype_delete (incl. the fast-delete loops and the
+			-- swapped record lookup); hooks may have moved the entity, so
+			-- re-read the archetype and row like the original call did.
+			archetype = record.archetype
+			local row = record.row
+			local columns = archetype.columns
+			local entities = archetype.entities
+			local last = #entities
+			local move = entities[last]
+
+			if row ~= last then
+				local record_to_move = eindex_sparse_array[move % ECS_ENTITY_MASK]
+				if record_to_move and record_to_move.dense ~= 0 then
+					record_to_move.row = row
+				end
+
+				entities[row] = move
+			end
+
+			entities[last] = nil :: any
+
+			if row == last then
+				for _, column in columns do
+					if column ~= NULL_ARRAY then
+						column[last] = nil
+					end
+				end
+			else
+				for _, column in columns do
+					if column ~= NULL_ARRAY then
+						column[row] = column[last]
+						column[last] = nil
+					end
+				end
+			end
 		end
 
-		local component_index = world.component_index
-		local archetypes = world.archetypes
-		local tgt = ECS_PAIR(EcsWildcard, entity)
-		local rel = ECS_PAIR(entity, EcsWildcard)
+		-- component_index/archetypes resolve to the world_new upvalues (the
+		-- same tables world.component_index/world.archetypes point at), and
+		-- the two wildcard probe ids are inlined ECS_PAIR calls.
+		local entity_lo = entity % ECS_ENTITY_MASK
+		local tgt = entity_lo + EcsWildcard * ECS_ENTITY_MASK + ECS_PAIR_OFFSET
+		local rel = EcsWildcard + entity_lo * ECS_ENTITY_MASK + ECS_PAIR_OFFSET
 
 		local idr_t = component_index[tgt]
 		local idr = component_index[entity]
@@ -3857,14 +3894,20 @@ local function world_new(DEBUG: boolean?)
 		entity_index.alive_count = i_swap - 1
 
 		local e_swap = eindex_dense_array[i_swap]
-		local r_swap = entity_index_try_get_any(e_swap) :: record
+		local r_swap = eindex_sparse_array[e_swap % ECS_ENTITY_MASK]
 		r_swap.dense = dense
 		record.archetype = ROOT_ARCHETYPE
 		record.row = 0
 		record.dense = i_swap
 
 		eindex_dense_array[dense] = e_swap
-		eindex_dense_array[i_swap] = ECS_GENERATION_INC(entity)
+		-- Inlined ECS_GENERATION_INC(entity): bump the generation, wrapping
+		-- to 0 at ECS_GENERATION_MASK. (The unified formula is exactly
+		-- equivalent to the original's two branches for every input.)
+		local next_gen = entity // ECS_ENTITY_MASK + 1
+		eindex_dense_array[i_swap] = if next_gen >= ECS_GENERATION_MASK
+			then entity_lo
+			else entity_lo + next_gen * ECS_ENTITY_MASK
 	end
 
 	local function world_clear(world: world, entity: i53)

--- a/src/jecs.luau
+++ b/src/jecs.luau
@@ -141,13 +141,24 @@ export type observer = {
 	query: query,
 }
 
+-- Cached column-relocation plan for one (from -> to) archetype transition:
+-- parallel arrays of the source's data columns and their matching destination
+-- columns (false when the component is dropped by the transition). Column
+-- tables are stable for an archetype's lifetime and archetype ids are never
+-- reused, so a plan stays valid as long as both archetypes exist.
+type moveplan = {
+	srcs: { Column },
+	dsts: { any },
+}
+
 type archetype = {
 	id: number,
 	types: { i53 },
 	type: string,
 	entities: { i53 },
 	columns: { Column },
-	columns_map: { [i53]: Column }
+	columns_map: { [i53]: Column },
+	move_plans: Map<i53, moveplan>?,
 }
 
 type componentrecord = {
@@ -1244,6 +1255,12 @@ local function archetype_destroy(world: world, archetype: archetype)
 	for id, node in edges do
 		archetype_edges[node.id][id] = nil
 		edges[id] = nil
+		-- Drop neighbors' cached move plans into this archetype; this
+		-- archetype's own plans die with it.
+		local node_plans = node.move_plans
+		if node_plans then
+			node_plans[archetype.id] = nil
+		end
 	end
 
 	local archetype_id = archetype.id
@@ -2780,6 +2797,14 @@ local function world_new(DEBUG: boolean?)
 	-- path for every archetype transition (set/add/remove), so the previous
 	-- new_entity/archetype_append/inner_archetype_move call chain is inlined
 	-- into a single function, and the duplicated dst_entities store is gone.
+	--
+	-- Column relocation runs off a cached per-transition move plan (see the
+	-- moveplan type): the first move along a (from -> to) transition resolves
+	-- each source column's destination via columns_map once, every later move
+	-- replays the plan with plain array reads. Plans for transitions into a
+	-- destroyed archetype are dropped in archetype_destroy via its edges;
+	-- entries created by non-edge moves (delete cascades) die with the source
+	-- archetype, which those paths destroy immediately after.
 	local function inner_entity_move(
 		entity: i53,
 		record: record,
@@ -2790,49 +2815,111 @@ local function world_new(DEBUG: boolean?)
 		local src_entities = from.entities
 		local dst_entities = to.entities
 		local dst_row = #dst_entities + 1
-
-		local src_columns = from.columns
 		local last = #src_entities
-		local id_types = from.types
-		local columns_map = to.columns_map
+		local src_columns = from.columns
 
-		if src_row ~= last then
-			for i, column in src_columns do
-				if column == NULL_ARRAY then
-					continue
+		if #src_columns < 3 then
+			-- Small source archetype: the plan-cache fetch costs more than
+			-- the one or two columns_map lookups it would save.
+			local id_types = from.types
+			local columns_map = to.columns_map
+
+			if src_row ~= last then
+				for i, column in src_columns do
+					if column == NULL_ARRAY then
+						continue
+					end
+					local dst_column = columns_map[id_types[i]]
+
+					if dst_column then
+						dst_column[dst_row] = column[src_row]
+					end
+
+					column[src_row] = column[last]
+					column[last] = nil
 				end
-				local dst_column = columns_map[id_types[i]]
 
-				if dst_column then
-					dst_column[dst_row] = column[src_row]
+				local e2 = src_entities[last]
+				src_entities[src_row] = e2
+
+				local record2 = eindex_sparse_array[e2 % ECS_ENTITY_MASK]
+				record2.row = src_row
+			else
+				for i, column in src_columns do
+					if column == NULL_ARRAY then
+						continue
+					end
+					-- Destination may not exist, e.g. when removing.
+					local dst_column = columns_map[id_types[i]]
+
+					if dst_column then
+						dst_column[dst_row] = column[src_row]
+					end
+
+					column[last] = nil
 				end
-
-				column[src_row] = column[last]
-				column[last] = nil
+			end
+		else
+			local existing_plans = from.move_plans
+			local plans: Map<i53, moveplan>
+			if existing_plans then
+				plans = existing_plans
+			else
+				plans = {}
+				from.move_plans = plans
+			end
+			local plan = plans[to.id]
+			local plan_srcs: { Column }
+			local plan_dsts: { any }
+			if plan then
+				plan_srcs = plan.srcs
+				plan_dsts = plan.dsts
+			else
+				plan_srcs = {}
+				plan_dsts = {}
+				local id_types = from.types
+				local columns_map = to.columns_map
+				local n = 0
+				for i, column in src_columns do
+					if column == NULL_ARRAY then
+						continue
+					end
+					n += 1
+					plan_srcs[n] = column
+					-- Destination may not exist, e.g. when removing.
+					plan_dsts[n] = columns_map[id_types[i]] or false
+				end
+				plans[to.id] = { srcs = plan_srcs, dsts = plan_dsts }
 			end
 
-			local e2 = src_entities[last]
-			src_entities[src_row] = e2
+			if src_row ~= last then
+				for k, column in plan_srcs do
+					local dst_column = plan_dsts[k]
+					if dst_column then
+						dst_column[dst_row] = column[src_row]
+					end
 
-			local record2 = eindex_sparse_array[e2 % ECS_ENTITY_MASK]
-			record2.row = src_row
-		else
-			for i, column in src_columns do
-				if column == NULL_ARRAY then
-					continue
-				end
-				-- Retrieves the new column index from the source archetype's record from each component
-				-- We have to do this because the columns are tightly packed and indexes may not correspond to each other.
-				local dst_column = columns_map[id_types[i]]
-
-				-- Sometimes target column may not exist, e.g. when you remove a component.
-				if dst_column then
-					dst_column[dst_row] = column[src_row]
+					column[src_row] = column[last]
+					column[last] = nil
 				end
 
-				column[last] = nil
+				local e2 = src_entities[last]
+				src_entities[src_row] = e2
+
+				local record2 = eindex_sparse_array[e2 % ECS_ENTITY_MASK]
+				record2.row = src_row
+			else
+				for k, column in plan_srcs do
+					local dst_column = plan_dsts[k]
+					if dst_column then
+						dst_column[dst_row] = column[src_row]
+					end
+
+					column[last] = nil
+				end
 			end
 		end
+
 		src_entities[last] = nil :: any
 		dst_entities[dst_row] = entity
 		record.archetype = to
@@ -3288,8 +3375,8 @@ local function world_new(DEBUG: boolean?)
 	end
 
 	local function world_target(world: world, entity: i53, relation: i53, index: number?): i53?
-		local record = entity_index_try_get_unsafe(entity)
-		if not record then
+		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
+		if not record or eindex_dense_array[record.dense] ~= entity then
 			return nil
 		end
 
@@ -3298,8 +3385,9 @@ local function world_new(DEBUG: boolean?)
 			return nil
 		end
 
-		local r = ECS_PAIR(relation, EcsWildcard)
-		local idr = world.component_index[r]
+		-- Inlined ECS_PAIR(relation, EcsWildcard).
+		local r = EcsWildcard + (relation % ECS_ENTITY_MASK) * ECS_ENTITY_MASK + ECS_PAIR_OFFSET
+		local idr = component_index[r]
 
 		if not idr then
 			return nil
@@ -3323,8 +3411,16 @@ local function world_new(DEBUG: boolean?)
 			return nil
 		end
 
-		return entity_index_get_alive(world.entity_index,
-		    ECS_PAIR_SECOND(nth))
+		-- Inlined entity_index_get_alive(entity_index, ECS_PAIR_SECOND(nth)).
+		local tr = eindex_sparse_array[(nth - ECS_PAIR_OFFSET) % ECS_ENTITY_MASK]
+		if not tr then
+			return nil
+		end
+		local dense = tr.dense
+		if dense == 0 or dense > entity_index.alive_count then
+			return nil
+		end
+		return eindex_dense_array[dense]
 	end
 
 	local NOOP = NOOP :: () -> i53
@@ -3371,8 +3467,48 @@ local function world_new(DEBUG: boolean?)
 		end
 	end
 
+	-- The ChildOf wildcard pair id is a constant for the world's lifetime.
+	local childof_wildcard: i53 = ECS_PAIR(EcsChildOf, EcsWildcard)
+
+	-- Specialized world_target(world, entity, EcsChildOf, 0): the relation is
+	-- known, index is always 0, and parent lookups are a per-frame staple.
 	local function world_parent(world: world, entity: i53): i53?
-		return world_target(world, entity, EcsChildOf, 0)
+		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
+		if not record or eindex_dense_array[record.dense] ~= entity then
+			return nil
+		end
+
+		local archetype = record.archetype
+		if not archetype then
+			return nil
+		end
+
+		local idr = component_index[childof_wildcard]
+		if not idr then
+			return nil
+		end
+
+		local archetype_id = archetype.id
+		local count = idr.counts[archetype_id]
+		if not count then
+			return nil
+		end
+
+		local nth = archetype.types[idr.records[archetype_id]]
+		if not nth then
+			return nil
+		end
+
+		-- Inlined entity_index_get_alive(entity_index, ECS_PAIR_SECOND(nth)).
+		local tr = eindex_sparse_array[(nth - ECS_PAIR_OFFSET) % ECS_ENTITY_MASK]
+		if not tr then
+			return nil
+		end
+		local dense = tr.dense
+		if dense == 0 or dense > entity_index.alive_count then
+			return nil
+		end
+		return eindex_dense_array[dense]
 	end
 
 	local function world_entity(world: world, entity: i53?): i53

--- a/src/jecs.luau
+++ b/src/jecs.luau
@@ -201,6 +201,11 @@ type world = {
 
 	observable: Map<i53, Map<i53, { Observer }>>,
 
+	-- Low 24 bits of every entity referenced by a component id (as the id
+	-- itself, a pair relation, or a pair target) -> true. Lets world_delete
+	-- skip its component_index probes for ordinary entities.
+	entity_used_as: Map<i24, boolean>,
+
 	range: (self: world, range_begin: number, range_end: number?) -> (),
 	entity: (self: world, id: i53?) -> i53,
 	component: (self: world) -> i53,
@@ -950,6 +955,17 @@ local function id_record_create(
 
 	component_index[id] = idr
 
+	-- Mark the entities this id references so world_delete knows it must run
+	-- its component_index probes for them; unmarked entities (the vast
+	-- majority) skip that cleanup entirely. id_record_create is the only
+	-- producer of component_index entries, so a missing mark cannot happen;
+	-- a stale mark only costs the probes, exactly like before.
+	local entity_used_as = world.entity_used_as
+	entity_used_as[relation % ECS_ENTITY_MASK] = true
+	if is_pair then
+		entity_used_as[(target :: number) % ECS_ENTITY_MASK] = true
+	end
+
 	return idr
 end
 
@@ -1192,50 +1208,8 @@ local function archetype_traverse_add(
 	return to
 end
 
-local function archetype_fast_delete_last(columns: { Column }, column_count: number)
-	for i, column in columns do
-		if column ~= NULL_ARRAY then
-			column[column_count] = nil
-		end
-	end
-end
-
-local function archetype_fast_delete(columns: { Column }, column_count: number, row: number)
-	for i, column in columns do
-		if column ~= NULL_ARRAY then
-			column[row] = column[column_count]
-			column[column_count] = nil
-		end
-	end
-end
-
-local function archetype_delete(world: world, archetype: archetype, row: number)
-	local entity_index = world.entity_index
-	local columns = archetype.columns
-	local entities = archetype.entities
-	local column_count = #entities
-	local last = #entities
-	local move = entities[last]
-	-- We assume first that the entity is the last in the archetype
-
-	if row ~= last then
-		local record_to_move = entity_index_try_get_any(entity_index, move)
-		if record_to_move then
-			record_to_move.row = row
-		end
-
-		entities[row] = move
-	end
-
-	entities[last] = nil :: any
-
-	if row == last then
-		archetype_fast_delete_last(columns, column_count)
-	else
-		archetype_fast_delete(columns, column_count, row)
-	end
-end
-
+-- NOTE: the old archetype_delete/archetype_fast_delete helpers were inlined
+-- into world_delete and world_clear (their only callers) and removed.
 
 local function archetype_destroy(world: world, archetype: archetype)
 	if archetype == world.ROOT_ARCHETYPE then
@@ -1318,6 +1292,14 @@ local function query_archetypes(query: query, override: boolean?)
 			return compatible_archetypes
 		end
 
+		-- idr.size is an upper bound on how many archetypes can match, so
+		-- presizing avoids every growth reallocation of the result array
+		-- (~14 of them for a 16k-archetype wildcard record). Iteration order
+		-- over idr.records is unchanged.
+		compatible_archetypes = table.create(idr.size) :: { archetype }
+		query.compatible_archetypes = compatible_archetypes
+		local compatible_count = 0
+
 		local without = query.filter_without
 
 		for archetype_id in idr.records do
@@ -1346,7 +1328,8 @@ local function query_archetypes(query: query, override: boolean?)
 				continue
 			end
 
-			table.insert(compatible_archetypes, archetype)
+			compatible_count += 1
+			compatible_archetypes[compatible_count] = archetype
 		end
 	end
 	return compatible_archetypes
@@ -2732,6 +2715,8 @@ local function world_new(DEBUG: boolean?)
 	-- `world:component` will not pollute the global registration of components.
 	local max_component_id = ecs_max_component_id
 
+	local entity_used_as = {} :: Map<i24, boolean>
+
 	local world = {
 		archetype_edges = archetype_edges,
 
@@ -2746,6 +2731,7 @@ local function world_new(DEBUG: boolean?)
 
 		observable = observable,
 		signals = signals,
+		entity_used_as = entity_used_as,
 	} :: world
 
 	local ROOT_ARCHETYPE = archetype_create(world, {}, "")
@@ -3356,19 +3342,21 @@ local function world_new(DEBUG: boolean?)
 			return nil
 		end
 
+		-- records[aid] exists iff counts[aid] >= 1 (they are created and
+		-- removed strictly together), so the common index-0 lookup needs only
+		-- the records probe; counts is consulted for explicit indexes only.
 		local archetype_id = archetype.id
-		local count = idr.counts[archetype_id]
-		if not count then
+		local tr_start = idr.records[archetype_id]
+		if not tr_start then
 			return nil
 		end
 
 		local nth = index or 0
-
-		if nth >= count then
+		if nth ~= 0 and nth >= idr.counts[archetype_id] then
 			return nil
 		end
 
-		nth = archetype.types[nth + idr.records[archetype_id]]
+		nth = archetype.types[nth + tr_start]
 
 		if not nth then
 			return nil
@@ -3451,13 +3439,14 @@ local function world_new(DEBUG: boolean?)
 			return nil
 		end
 
-		local archetype_id = archetype.id
-		local count = idr.counts[archetype_id]
-		if not count then
+		-- records[aid] exists iff counts[aid] >= 1, and parent always wants
+		-- index 0, so the counts probe is skipped entirely.
+		local tr_start = idr.records[archetype.id]
+		if not tr_start then
 			return nil
 		end
 
-		local nth = archetype.types[idr.records[archetype_id]]
+		local nth = archetype.types[tr_start]
 		if not nth then
 			return nil
 		end
@@ -3680,13 +3669,24 @@ local function world_new(DEBUG: boolean?)
 		-- component_index/archetypes resolve to the world_new upvalues (the
 		-- same tables world.component_index/world.archetypes point at), and
 		-- the two wildcard probe ids are inlined ECS_PAIR calls.
+		--
+		-- Ordinary entities are never referenced by any component id (as the
+		-- id itself, a relation, or a pair target), so all three probes below
+		-- would miss. entity_used_as — maintained by id_record_create, the
+		-- only producer of component_index entries — tells us when the probes
+		-- can be skipped outright; the cleanup blocks then no-op on nil.
 		local entity_lo = entity % ECS_ENTITY_MASK
-		local tgt = entity_lo + EcsWildcard * ECS_ENTITY_MASK + ECS_PAIR_OFFSET
-		local rel = EcsWildcard + entity_lo * ECS_ENTITY_MASK + ECS_PAIR_OFFSET
+		local used = entity_used_as[entity_lo]
 
-		local idr_t = component_index[tgt]
-		local idr = component_index[entity]
-		local idr_r = component_index[rel]
+		local idr_t, idr, idr_r
+		if used then
+			local tgt = entity_lo + EcsWildcard * ECS_ENTITY_MASK + ECS_PAIR_OFFSET
+			local rel = EcsWildcard + entity_lo * ECS_ENTITY_MASK + ECS_PAIR_OFFSET
+
+			idr_t = component_index[tgt]
+			idr = component_index[entity]
+			idr_r = component_index[rel]
+		end
 
 		--[[
 			It is important to note that `world_delete` uses a depth-first
@@ -3895,6 +3895,12 @@ local function world_new(DEBUG: boolean?)
 			end
 		end
 
+		if used then
+			-- The cleanup above removed every component_index entry that
+			-- referenced this entity, so the next generation starts unmarked.
+			entity_used_as[entity_lo] = nil
+		end
+
 		local dense = record.dense
 		local i_swap = entity_index.alive_count
 		entity_index.alive_count = i_swap - 1
@@ -3917,8 +3923,8 @@ local function world_new(DEBUG: boolean?)
 	end
 
 	local function world_clear(world: world, entity: i53)
-		local record = entity_index_try_get_unsafe(entity)
-		if not record then
+		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
+		if not record or eindex_dense_array[record.dense] ~= entity then
 			return
 		end
 
@@ -3930,8 +3936,44 @@ local function world_new(DEBUG: boolean?)
 				on_remove(entity, id)
 			end
 		end
-		archetype_delete(world, record.archetype, record.row)
-		record.archetype = world.ROOT_ARCHETYPE
+
+		-- Inlined archetype_delete (mirrors world_delete); hooks may have
+		-- moved the entity, so re-read the archetype and row like the
+		-- original call did.
+		archetype = record.archetype
+		local row = record.row
+		local columns = archetype.columns
+		local entities = archetype.entities
+		local last = #entities
+		local move = entities[last]
+
+		if row ~= last then
+			local record_to_move = eindex_sparse_array[move % ECS_ENTITY_MASK]
+			if record_to_move and record_to_move.dense ~= 0 then
+				record_to_move.row = row
+			end
+
+			entities[row] = move
+		end
+
+		entities[last] = nil :: any
+
+		if row == last then
+			for _, column in columns do
+				if column ~= NULL_ARRAY then
+					column[last] = nil
+				end
+			end
+		else
+			for _, column in columns do
+				if column ~= NULL_ARRAY then
+					column[row] = column[last]
+					column[last] = nil
+				end
+			end
+		end
+
+		record.archetype = ROOT_ARCHETYPE
 		record.row = 0
 	end
 

--- a/src/jecs.luau
+++ b/src/jecs.luau
@@ -2559,43 +2559,6 @@ local function world_query(world: World, ...)
 
 	return q
 end
-local function world_each(world: world, id: i53): () -> i53
-	local idr = world.component_index[id]
-	if not idr then
-		return NOOP :: () -> i53
-	end
-
-	local records = idr.records
-	local archetypes = world.archetypes
-	local archetype_id = next(records, nil) :: number
-	local archetype = archetypes[archetype_id]
-	if not archetype then
-		return NOOP :: () -> i53
-	end
-
-	local entities = archetype.entities
-	local row = #entities
-
-	return function()
-		local entity = entities[row]
-		while not entity do
-			archetype_id = next(records, archetype_id) :: number
-			if not archetype_id then
-				return nil :: any
-			end
-			archetype = archetypes[archetype_id]
-			entities = archetype.entities
-			row = #entities
-			entity = entities[row]
-		end
-		row -= 1
-		return entity
-	end
-end
-
-local function world_children(world: world, parent: i53)
-	return world_each(world, ECS_PAIR(EcsChildOf, parent))
-end
 
 local function ecs_bulk_insert(world: world, entity: i53, ids: { i53 }, values: { any })
 	local entity_index = world.entity_index
@@ -3511,12 +3474,55 @@ local function world_new(DEBUG: boolean?)
 		return eindex_dense_array[dense]
 	end
 
+	-- World-local: component_index/archetypes as upvalues instead of world
+	-- field reads per call. The iterator body is unchanged.
+	local function world_each(world: world, id: i53): () -> i53
+		local idr = component_index[id]
+		if not idr then
+			return NOOP :: () -> i53
+		end
+
+		local records = idr.records
+		local archetype_id = next(records, nil) :: number
+		local archetype = archetypes[archetype_id]
+		if not archetype then
+			return NOOP :: () -> i53
+		end
+
+		local entities = archetype.entities
+		local row = #entities
+
+		return function()
+			local entity = entities[row]
+			while not entity do
+				archetype_id = next(records, archetype_id) :: number
+				if not archetype_id then
+					return nil :: any
+				end
+				archetype = archetypes[archetype_id]
+				entities = archetype.entities
+				row = #entities
+				entity = entities[row]
+			end
+			row -= 1
+			return entity
+		end
+	end
+
+	-- The ChildOf pair base is constant: pair(ChildOf, parent) is just
+	-- parent's low bits plus this offset.
+	local childof_pair_base: i53 = EcsChildOf * ECS_ENTITY_MASK + ECS_PAIR_OFFSET
+
+	local function world_children(world: world, parent: i53)
+		return world_each(world, parent % ECS_ENTITY_MASK + childof_pair_base)
+	end
+
 	local function world_entity(world: world, entity: i53?): i53
 		local sparse_array = eindex_sparse_array
 		local dense_array = eindex_dense_array
-		
+
 		if entity then
-			local index = ECS_ID(entity)
+			local index = entity % ECS_ENTITY_MASK
 			local alive_count = entity_index.alive_count
 			local r = sparse_array[index]
 			if r then
@@ -3938,7 +3944,18 @@ local function world_new(DEBUG: boolean?)
 	end
 
 	local function world_contains(world: world, entity: i53): boolean
-		return entity_index_is_alive(entity_index, entity)
+		-- Inlined entity_index_is_alive -> entity_index_try_get: alive means
+		-- the sparse record exists, is allocated (dense ~= 0), sits within
+		-- the alive range, and the dense slot holds this exact generation.
+		local record = eindex_sparse_array[entity % ECS_ENTITY_MASK]
+		if not record then
+			return false
+		end
+		local dense = record.dense
+		if dense == 0 or dense > entity_index.alive_count then
+			return false
+		end
+		return eindex_dense_array[dense] == entity
 	end
 
 	local function world_cleanup(world: world)


### PR DESCRIPTION
> [!NOTE]
> **Authorship disclosure:** these optimizations were researched, implemented, and benchmarked by **Claude (Fable 5, Anthropic's model) running in Claude Code** — including the failed experiments documented below. My role (@Pyseph) was direction, supervision, and independent verification: I ran every Studio benchmark round on real hardware and reviewed each round's results before the next began. Every commit carries a `Co-Authored-By: Claude` trailer. Flagging this up front so reviewers can calibrate scrutiny accordingly — though the work was held to the repo's own standard: nothing landed without surviving the full test suite, a >=80% win-rate A/B verdict, and a recompile confirmation.

## Summary

Six self-contained performance commits to `src/jecs.luau`, developed and verified against this exact base commit (30876015). **18 benchmarked workloads get faster, 0 get slower, and behavior is bit-for-bit compatible** — the full test suite (139 cases) passes after every individual commit, and `luau-analyze` stays clean throughout.

Final A/B numbers, measured in Roblox Studio under `--!native --!optimize 2` (methodology below):

| workload | faster by | won rounds |
|---|---|---|
| `world:parent` | **+34.9%** | 100% |
| `world:contains` | **+34.7%** | 100% |
| `world:target` | **+32.8%** | 100% |
| remove a component from a 5-component entity | +24.8% | 100% |
| `world:delete` (ChildOf child / plain 4-component) | +19.5% / +19.2% | 100% |
| `world:remove` | +18.0% | 100% |
| `world:add` (tag) | +16.4% | 93% |
| `world:children` (16k parents × 4 children) | +15.0% | 85% |
| `world:add` ChildOf (exclusive pair) | +14.4% | 100% |
| add a 5th component to a 4-component entity | +14.0% | 100% |
| `world:has` | +11.2% | 90% |
| `world:clear` | +9.8% | 100% |
| `world:set` (pair) | +8.9% | 100% |
| `world:get` (4 comps / 1 comp) | +8.3% / +7.1% | 97% / 82% |
| `world:set` (add / overwrite) | +6.2% / +4.2% | 83% / 88% |

Query iteration is **deliberately untouched** (byte-identical) — see "Failed experiments" for why that is a feature of this PR, not an omission.

## Methodology

All numbers come from an A/B harness that loads the optimized copy and this base commit as two independent ModuleScripts and runs identical workloads against both, interleaved round-by-round with alternating order so GC/scheduler drift hits both sides equally. The reported time is the best-of-60-rounds (the run least disturbed by GC), and a result only counts as a win when the delta clears 1.5% **and** the optimized side wins ≥80% of paired rounds.

Two disciplines mattered more than expected:

- **Per-build bias is real.** Two independently compiled copies of *byte-identical* source showed stable ±2–3% deltas (occasionally more) from native code layout alone. Every claimed win was therefore confirmed across a forced recompile — a result that moves with the layout is an artifact, one that survives is real.
- **Win-rate gates beat deltas.** Allocation-heavy workloads (spawning, mass deletion) have best-of deltas that swing wildly with GC; the share-of-rounds-won is far more stable and is what separated real wins from noise.

Correctness was held to "bit-for-bit": beyond the test suite, the changes preserve pinned-but-obscure semantics — setting a value on a tag still errors *after* the tag was added (the frozen `NULL_ARRAY` write is the error mechanism), `on_remove` hooks may move the entity mid-remove and the operation re-reads `record.archetype` afterward, exclusive-pair replacement fires hooks on warm edge-cache hits, and generation arithmetic (including the wrap at 2^16) is value-identical for every input.

## What each commit does

1. **Inline hot-path helper calls in entity operations.** Luau's `-O2` inliner only handles simple local functions, so `entity_index_try_get_unsafe`, `fetch`, the `new_entity`/`archetype_append`/`inner_archetype_move` chain, and the pair-math helpers were real call frames on every `get`/`has`/`set`/`add`/`remove` — frequently costing more than the work they wrapped. The fused move also removes a duplicated `dst_entities` store the old chain made.
2. **Per-transition move plans + `target`/`parent` inlining.** Archetype moves resolved every column's destination through `columns_map` per entity; the first move along a `(from → to)` transition now caches a column-mapping plan that later moves replay with array reads. A gate keeps sources with <3 columns on the direct loop — without it, single-column removes regressed (measured, see below). `world_parent` becomes a specialized reader with the ChildOf wildcard id precomputed per world.
3. **`world_delete`/`world_targets` inlining.** The delete path dropped ~6 call frames, including the whole `archetype_delete` body and a value-identical unified form of `ECS_GENERATION_INC`.
4. **`world_contains` inlining + `each`/`children` specialization.** `contains` was three calls deep for a boolean.
5. **Delete probe-skip + counts-lookup elimination + `clear` inlining.** The biggest single idea, adapted from flecs: ordinary entities are never used as a component id, pair relation, or pair target, so `world_delete`'s three wildcard `component_index` probes always miss for them. `id_record_create` (the only producer of such records) now marks referenced entities in `world.entity_used_as`; deleting unmarked entities skips the probes and pair arithmetic entirely, and the mark is cleared on delete so recycled ids start clean. Stale marks are safe (they just fall back to probe-and-miss); missing marks cannot occur. Separately, `records[aid]` exists iff `counts[aid] ≥ 1`, so `target`/`parent`'s index-0 path drops a redundant hash lookup — this took `target` from +14.5% to +32.8%.
6. **Fused liveness check (`record.entity`).** Handle validation drops from a dependent two-load chain (`record.dense` → `dense_array[dense]` → compare) to a single field compare, maintained at every alive-making site. This lifted every operation a further +2–12% over commit 5.

## Mistakes made and lessons learned

These cost real time and are worth recording for anyone optimizing this codebase later:

- **Query iterator "improvements" measure slower under native codegen.** Restructuring the per-entity `next()` closures to read the boxed row-counter upvalue once instead of three times (and to fold column reads into the return expression) looks strictly better in bytecode terms — and consistently measured *slower* for high arities (the 8-component case lost 100% of rounds). Native codegen schedules the original's up-front column loads better than the "cleverer" shape. The iterators in this PR are byte-identical to base because every alternative was tried and lost.
- **Archetype list order affects iteration speed.** Swapping `query_archetypes` from hash-walking `idr.records` to scanning the (cheaper) `idr.cache` array changed the order of `compatible_archetypes` — and cached-query iteration regressed 7% while wildcard queries regressed ~20%. The scan was never the cost; the order was. Reverted. (The `table.create` presizing in commit 5 keeps hash order exactly for this reason.)
- **Cache fetches have to amortize.** The move-plan cache as first written regressed single-column removes from +18% to +3.6% because the plan fetch (~4 reads) costs more than the one lookup it saves. The <3-column gate in commit 2 is load-bearing, not decoration.
- **Table literal key order is a performance interface.** Adding `record.entity` as the *first* constructor key reproducibly regressed the 4-component `get` path by 3–5% across recompiles — the insertion order shifted which keys win the record table's internal hash slots. Appending it last fixed it. If you add fields to hot record-shaped tables, append them.
- **A microbenchmark can lie in both directions.** A CLI harness (luau 0.724, `--codegen`) predicted Studio results case-for-case for five rounds, then showed a phantom −3.4% on one case in round 6 that Studio measured as +8.3%. Conversely, byte-identical code routinely read ±3% in either harness. Nothing here was landed on a single environment's say-so.

## What was deliberately not done

- **SoA entity records** (parallel `dense`/`row`/`archetype` arrays instead of per-entity tables) is the largest remaining win — it would make `world:entity()` allocation-free — but it breaks the exported `Record`/`jecs.record` API shape, so it belongs in a design discussion rather than this PR.
- **Iterator closure elimination** in `targets`/`each`: every variant breaks the public directly-callable `() -> Id` contract or nested iteration.
- Spawn-path allocation: the per-entity record table is inherent to the current API and the workload is GC-jitter-dominated anyway.

## Test plan

- `luau test/tests.luau` — 139/139 after each commit (also run with `-O2`).
- `luau-analyze src/jecs.luau` — clean after each commit.
- Studio A/B benchmark suite (29 workloads spanning reads, writes, archetype moves, relationships, hierarchy iteration, lifecycle): 18 FASTER / 0 SLOWER at the tip; the remainder are byte-identical code paths or documented GC-jitter cases reading as noise.

The benchmark harness itself (runner with interleaved best-of/win-rate verdicts plus the workload suite) lives in a separate repo and can be contributed too if there's interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
