### PR TITLE
Fix world: get returning nil after root archetype churn and unrelated delete

### DIFF
--- a/src/jecs.luau
+++ b/src/jecs.luau
@@ -2976,6 +2976,10 @@ local function world_new(DEBUG: boolean?)
 				-- If there was a previous archetype, then the entity needs to move the archetype
 				inner_entity_move(entity, record, to)
 			else
+				-- An entity moved back to root keeps a real slot in root.entities; remove it before the append, else a later delete of any root entity stomps this record's row.
+				if record.row ~= 0 then
+					archetype_delete(world, src, record.row)
+				end
 				new_entity(entity, record, to)
 			end
 
@@ -3074,6 +3078,10 @@ local function world_new(DEBUG: boolean?)
 		if not src_is_root_archetype then
 			inner_entity_move(entity, record, to)
 		else
+			-- An entity moved back to root keeps a real slot in root.entities; remove it before the append, else a later delete of any root entity stomps this record's row.
+			if record.row ~= 0 then
+				archetype_delete(world, src, record.row)
+			end
 			if #to.types > 0 then
 				new_entity(entity, record, to)
 			end

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -268,6 +268,32 @@ TEST("reproduce idr_t nil archetype bug", function()
     end
 end)
 
+TEST("get after root archetype churn and unrelated delete", function()
+	local world = jecs.world(true)
+	local C3 = world:component()
+	local C4 = world:component()
+
+	-- Entity a churns through root: gains C3, loses it (back to root), gains C4
+	local a = world:entity()
+	world:set(a, C3, 490494)
+	world:remove(a, C3)
+	world:set(a, C4, 892027)
+
+	-- Deleting any root-resident entity used to stomp a's record.row
+	local b = world:entity()
+	world:delete(b)
+
+	CHECK(world:get(a, C4) == 892027)
+	CHECK(world:has(a, C4))
+	local found
+	for e, v in world:query(C4) do
+		if e == a then
+			found = v
+		end
+	end
+	CHECK(found == 892027)
+end)
+
 TEST("Ensure archetype edges get cleaned", function()
 	local A = jecs.component()
 	local B = jecs.component()


### PR DESCRIPTION
## Brief Description of your Changes

world:get returns nil for a component an entity actually has, once the entity has passed through the root archetype and any root resident entity is later deleted. has and queries still report the component correctly, so the value looks present everywhere except get.

No existing issue for this, so here is a deterministic repro:
```lua
local world = jecs.world()
local C3, C4 = world:component(), world:component()

local a = world:entity()
world:set(a, C3, 490494)
world:remove(a, C3)   -- a moves back to root, stored in root.entities at a real row
world:set(a, C4, 892027)

local b = world:entity()
world:delete(b)        -- deleting a root entity swap removes from root.entities

print(world:get(a, C4)) -- nil, expected 892027
print(world:has(a, C4)) -- true
```
The root archetype is handled inconsistently between move in and move out. Moving an entity back to root (removing its last component) appends it to root.entities at a real row. Moving it out of root again hits the src_is_root_archetype shortcut, which calls the append only new_entity and never removes the stale root.entities entry. A later world:delete of any root entity then runs archetype_delete on root, swap removes using that stale entry, and overwrites its record.row. get resolves through record.row and reads the wrong slot.

The fix swap removes the entity from root.entities before the append at both move out sites, but only when it holds a real row (record.row ~= 0), reusing the existing archetype_delete.

## Impact of your Changes

Corrects the bad nil return. No other behavior changes. The common path is untouched: fresh entities are rowless (record.row == 0) and skip the new branch entirely, so they only pay a single integer comparison. The extra archetype_delete runs only for the rare case of an entity that was rowed back into root. No data model or API change.

## Tests Performed

Added a regression test beside the reproduce idr_t nil archetype bug test. That existing test checks parent and query but never reads a get value, which is the gap that let this through.

The full suite stays at 140/140. The new test fails on stock (139/140) and passes with the fix, so it covers the bug. Also confirmed against a standalone repro on the current main.

## Additional Comments

There is a cleaner direction: make the root archetype truly rowless so the move out shortcut is always correct and root.entities is never populated. That is a data model decision (whether anything relies on root entities being listed in root.entities), so I went with the minimal fix here. Happy to take it that way if you prefer.