### PR TITLE
Fix world: Skip dead targets in the world:targets iterator

### DIFF
--- a/src/jecs.luau
+++ b/src/jecs.luau
@@ -3342,16 +3342,16 @@ local function world_new(DEBUG: boolean?)
 		local end_count = nth + count
 
 		local archetype_types = archetype.types
-		local sparse_array = entity_index.sparse_array
-		local dense_array = entity_index.dense_array
 
 		return function(): i53?
-			if nth == end_count then
-				return nil
+			while nth ~= end_count do
+				local target = entity_index_get_alive(entity_index, ECS_PAIR_SECOND(archetype_types[nth]))
+				nth += 1
+				if target then
+					return target
+				end
 			end
-			local target = dense_array[sparse_array[ECS_PAIR_SECOND(archetype_types[nth])].dense]
-			nth += 1
-			return target
+			return nil
 		end
 	end
 

--- a/test/tests.luau
+++ b/test/tests.luau
@@ -3300,6 +3300,29 @@ TEST("world:targets()", function()
 
 		CHECK(count == #alive)
 	end
+	do CASE "should skip targets deleted after the iterator is created"
+		local world = jecs.world()
+
+		local ROOT = world:entity()
+		local e = world:entity()
+		local a, b, c = world:entity(), world:entity(), world:entity()
+		world:add(e, pair(ROOT, a))
+		world:add(e, pair(ROOT, b))
+		world:add(e, pair(ROOT, c))
+
+		local iter = world:targets(e, ROOT)
+		world:delete(b)
+
+		local seen = {}
+		for t in iter do
+			CHECK(world:contains(t))
+			seen[#seen + 1] = t
+		end
+
+		CHECK(#seen == 2)
+		CHECK(seen[1] == a)
+		CHECK(seen[2] == c)
+	end
 	do CASE "should properly handle rapid add/remove calls"
 		local world = jecs.world()
 


### PR DESCRIPTION
## Brief Description of your Changes

world:targets yields a non-alive entity id for a relationship target that is deleted after the iterator is created but before that target is reached. world:target and world:contains both report the target as gone, so only the targets iterator surfaces the bad id. Reading each target and deleting it in the same loop is unaffected, since every target is still alive when it is read.

No existing issue for this, so here is a deterministic repro:
```lua
local world = jecs.world()
local pair = jecs.pair

local ROOT = world:entity()
local e = world:entity()
local a, b, c = world:entity(), world:entity(), world:entity()
world:add(e, pair(ROOT, a))
world:add(e, pair(ROOT, b))
world:add(e, pair(ROOT, c))

local iter = world:targets(e, ROOT) -- snapshot taken here, includes b
world:delete(b)                     -- b dies after the iterator was created

for t in iter do
	print(t, world:contains(t))     -- yields b's ghost id with contains == false
end
print(world:target(e, ROOT, 0), world:target(e, ROOT, 1)) -- a, c, the correct answer
```
world:targets snapshots the archetype types, the start offset and the count when the iterator is created, then resolves each target with a raw dense_array[sparse_array[...].dense]. Unlike world:target, which resolves through entity_index_get_alive, the iterator never checks dense > alive_count and never guards a missing sparse record. When a target dies after the snapshot, its dense slot moves past alive_count, so the raw read returns the generation-bumped ghost of the dead target, or a live entity that later reused the slot.

The fix resolves each target through entity_index_get_alive, the same helper world:target uses, and skips targets that are no longer alive instead of yielding them. The now unused captured sparse_array and dense_array locals are dropped.

## Impact of your Changes

Corrects the bad target id. world:targets now yields only live targets, matching world:target and the existing "should ignore deleted targets" intent. The common all live path is unchanged in behavior. No data model or API change.

## Tests Performed

Added a regression test beside the existing world:targets cases that deletes a target after obtaining the iterator and checks every yielded id is contained. The existing "should ignore deleted targets" case deletes before the iterator is created, so cleanup removes the pair before the snapshot and never exercised this path.

The full suite stays at 140/140. The new test fails on stock (139/140) and passes with the fix. Also confirmed against a standalone repro on current main.

## Additional Comments

world:target already guards this through entity_index_get_alive. The plural iterator just missed it, so I kept the fix minimal by reusing the same helper rather than inlining.

PR #317 rewrites world_targets and keeps the same raw lookup, so it would need this guard too.
